### PR TITLE
feat: Time travel — read historical snapshots by version or timestamp

### DIFF
--- a/src/main/java/io/ducklake/spark/DuckLakeDataSource.java
+++ b/src/main/java/io/ducklake/spark/DuckLakeDataSource.java
@@ -21,6 +21,10 @@ import java.util.*;
  *     .option("catalog", "/path/to/catalog.ducklake")
  *     .option("table", "my_table")
  *     .load()
+ *
+ * Time travel:
+ *   .option("snapshot_version", 3)          // read at version 3
+ *   .option("snapshot_time", "2026-01-01T00:00:00")  // read at timestamp
  */
 public class DuckLakeDataSource implements TableProvider {
 
@@ -29,11 +33,17 @@ public class DuckLakeDataSource implements TableProvider {
         try (DuckLakeMetadataBackend backend = createBackend(options)) {
             String tableName = getTableName(options);
             String schemaName = options.getOrDefault("schema", "main");
-            DuckLakeMetadataBackend.TableInfo table = backend.getTable(tableName, schemaName);
+
+            // Resolve snapshot for time travel
+            long snapshotId = backend.resolveSnapshotId(
+                    options.getOrDefault("snapshot_version", null),
+                    options.getOrDefault("snapshot_time", null));
+
+            DuckLakeMetadataBackend.TableInfo table = backend.getTable(tableName, schemaName, snapshotId);
             if (table == null) {
                 throw new IllegalArgumentException("Table not found: " + schemaName + "." + tableName);
             }
-            var columns = backend.getColumns(table.tableId);
+            var columns = backend.getColumns(table.tableId, snapshotId);
             return DuckLakeTypeMapping.buildSchema(columns);
         } catch (SQLException e) {
             throw new RuntimeException("Failed to infer schema from DuckLake catalog", e);

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
@@ -69,6 +69,102 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
     }
 
     // ---------------------------------------------------------------
+    // Snapshot queries (time travel)
+    // ---------------------------------------------------------------
+
+    /** Get snapshot by version (snapshot_id). Returns null if not found. */
+    public SnapshotInfo getSnapshotAtVersion(long version) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "SELECT snapshot_id, snapshot_time, snapshot_changes " +
+                "FROM ducklake_snapshot WHERE snapshot_id = ?")) {
+            ps.setLong(1, version);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new SnapshotInfo(
+                            rs.getLong("snapshot_id"),
+                            rs.getString("snapshot_time"),
+                            rs.getString("snapshot_changes"));
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Get the latest snapshot at or before the given timestamp. Returns null if none found. */
+    public SnapshotInfo getSnapshotAtTime(String timestamp) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "SELECT snapshot_id, snapshot_time, snapshot_changes " +
+                "FROM ducklake_snapshot " +
+                "WHERE snapshot_time <= ? ORDER BY snapshot_id DESC LIMIT 1")) {
+            ps.setString(1, timestamp);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new SnapshotInfo(
+                            rs.getLong("snapshot_id"),
+                            rs.getString("snapshot_time"),
+                            rs.getString("snapshot_changes"));
+                }
+            }
+        }
+        return null;
+    }
+
+    /** List all snapshots ordered by version (ascending). */
+    public List<SnapshotInfo> listSnapshots() throws SQLException {
+        List<SnapshotInfo> result = new ArrayList<>();
+        try (Statement s = getConnection().createStatement();
+             ResultSet rs = s.executeQuery(
+                     "SELECT snapshot_id, snapshot_time, snapshot_changes " +
+                     "FROM ducklake_snapshot ORDER BY snapshot_id")) {
+            while (rs.next()) {
+                result.add(new SnapshotInfo(
+                        rs.getLong("snapshot_id"),
+                        rs.getString("snapshot_time"),
+                        rs.getString("snapshot_changes")));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Resolve a snapshot ID from version/time options.
+     * Returns the current (latest) snapshot if neither is specified.
+     *
+     * @param snapshotVersion version string (snapshot_id), or null
+     * @param snapshotTime    ISO-8601 timestamp string, or null
+     * @throws IllegalArgumentException if both are set, or if the target snapshot is not found
+     */
+    public long resolveSnapshotId(String snapshotVersion, String snapshotTime) throws SQLException {
+        if (snapshotVersion != null && snapshotTime != null) {
+            throw new IllegalArgumentException(
+                    "Cannot specify both 'snapshot_version' and 'snapshot_time' -- use one or the other");
+        }
+        if (snapshotVersion != null) {
+            long version;
+            try {
+                version = Long.parseLong(snapshotVersion);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "Invalid snapshot_version: " + snapshotVersion + " -- must be a numeric version");
+            }
+            SnapshotInfo snap = getSnapshotAtVersion(version);
+            if (snap == null) {
+                throw new IllegalArgumentException("Snapshot version " + version + " not found");
+            }
+            return snap.snapshotId;
+        }
+        if (snapshotTime != null) {
+            SnapshotInfo snap = getSnapshotAtTime(snapshotTime);
+            if (snap == null) {
+                throw new IllegalArgumentException(
+                        "No snapshot found at or before timestamp: " + snapshotTime);
+            }
+            return snap.snapshotId;
+        }
+        return getCurrentSnapshotId();
+    }
+
+    // ---------------------------------------------------------------
     // Schema queries
     // ---------------------------------------------------------------
 
@@ -155,9 +251,13 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         return getTable(tableName, "main");
     }
 
-    /** Get a table by name in a named schema. */
+    /** Get a table by name in a named schema at the current snapshot. */
     public TableInfo getTable(String tableName, String schemaName) throws SQLException {
-        long snap = getCurrentSnapshotId();
+        return getTable(tableName, schemaName, getCurrentSnapshotId());
+    }
+
+    /** Get a table by name in a named schema at a specific snapshot. */
+    public TableInfo getTable(String tableName, String schemaName, long snapshotId) throws SQLException {
         try (PreparedStatement ps = getConnection().prepareStatement(
                 "SELECT t.table_id, t.table_uuid, t.table_name, t.path, t.path_is_relative " +
                 "FROM ducklake_table t " +
@@ -167,10 +267,10 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
                 "AND s.begin_snapshot <= ? AND (s.end_snapshot IS NULL OR s.end_snapshot > ?)")) {
             ps.setString(1, schemaName);
             ps.setString(2, tableName);
-            ps.setLong(3, snap);
-            ps.setLong(4, snap);
-            ps.setLong(5, snap);
-            ps.setLong(6, snap);
+            ps.setLong(3, snapshotId);
+            ps.setLong(4, snapshotId);
+            ps.setLong(5, snapshotId);
+            ps.setLong(6, snapshotId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     return new TableInfo(
@@ -263,9 +363,13 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         return result;
     }
 
-    /** Get active delete files for a data file. */
+    /** Get active delete files for a data file at the current snapshot. */
     public List<DeleteFileInfo> getDeleteFiles(long tableId, long dataFileId) throws SQLException {
-        long snap = getCurrentSnapshotId();
+        return getDeleteFiles(tableId, dataFileId, getCurrentSnapshotId());
+    }
+
+    /** Get active delete files for a data file at a specific snapshot. */
+    public List<DeleteFileInfo> getDeleteFiles(long tableId, long dataFileId, long snapshotId) throws SQLException {
         List<DeleteFileInfo> result = new ArrayList<>();
         try (PreparedStatement ps = getConnection().prepareStatement(
                 "SELECT delete_file_id, path, path_is_relative, format, delete_count " +
@@ -274,8 +378,8 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
                 "AND begin_snapshot <= ? AND (end_snapshot IS NULL OR end_snapshot > ?)")) {
             ps.setLong(1, tableId);
             ps.setLong(2, dataFileId);
-            ps.setLong(3, snap);
-            ps.setLong(4, snap);
+            ps.setLong(3, snapshotId);
+            ps.setLong(4, snapshotId);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     result.add(new DeleteFileInfo(
@@ -392,6 +496,18 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
     // ---------------------------------------------------------------
     // Data classes
     // ---------------------------------------------------------------
+
+    public static class SnapshotInfo {
+        public final long snapshotId;
+        public final String snapshotTime;
+        public final String changes;
+
+        public SnapshotInfo(long snapshotId, String snapshotTime, String changes) {
+            this.snapshotId = snapshotId;
+            this.snapshotTime = snapshotTime;
+            this.changes = changes;
+        }
+    }
 
     public static class SchemaInfo {
         public final long schemaId;

--- a/src/main/java/io/ducklake/spark/reader/DuckLakeScan.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakeScan.java
@@ -14,6 +14,8 @@ import java.util.*;
 /**
  * Represents a scan of a DuckLake table. Plans input partitions
  * (one per data file) and handles file pruning via column statistics.
+ *
+ * Supports time travel via snapshot_version / snapshot_time options.
  */
 public class DuckLakeScan implements Scan, Batch {
 
@@ -45,16 +47,22 @@ public class DuckLakeScan implements Scan, Batch {
         try (DuckLakeMetadataBackend backend = createBackend()) {
             String tableName = options.get("table");
             String schemaName = options.getOrDefault("schema", "main");
-            TableInfo table = backend.getTable(tableName, schemaName);
+
+            // Resolve snapshot for time travel
+            long snapshotId = backend.resolveSnapshotId(
+                    options.getOrDefault("snapshot_version", null),
+                    options.getOrDefault("snapshot_time", null));
+
+            TableInfo table = backend.getTable(tableName, schemaName, snapshotId);
             if (table == null) {
                 throw new RuntimeException("Table not found: " + schemaName + "." + tableName);
             }
 
             String dataPath = backend.getDataPath();
-            List<DataFileInfo> files = backend.getDataFiles(table.tableId);
-            List<ColumnInfo> columns = backend.getColumns(table.tableId);
+            List<DataFileInfo> files = backend.getDataFiles(table.tableId, snapshotId);
+            List<ColumnInfo> columns = backend.getColumns(table.tableId, snapshotId);
 
-            // Build column ID → name mapping for stats-based pruning
+            // Build column ID -> name mapping for stats-based pruning
             Map<Long, String> colIdToName = new HashMap<>();
             for (ColumnInfo col : columns) {
                 colIdToName.put(col.columnId, col.name);
@@ -65,8 +73,9 @@ public class DuckLakeScan implements Scan, Batch {
                 // Resolve file path
                 String filePath = file.pathIsRelative ? dataPath + file.path : file.path;
 
-                // Get delete files for this data file
-                List<DeleteFileInfo> deleteFiles = backend.getDeleteFiles(table.tableId, file.dataFileId);
+                // Get delete files for this data file at the target snapshot
+                List<DeleteFileInfo> deleteFiles = backend.getDeleteFiles(
+                        table.tableId, file.dataFileId, snapshotId);
                 List<String> deletePaths = new ArrayList<>();
                 for (DeleteFileInfo df : deleteFiles) {
                     deletePaths.add(df.pathIsRelative ? dataPath + df.path : df.path);

--- a/src/test/java/io/ducklake/spark/DuckLakeTimeTravelTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeTimeTravelTest.java
@@ -1,0 +1,316 @@
+package io.ducklake.spark;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.sql.*;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for DuckLake time travel: reading historical snapshots
+ * by version (snapshot_id) or by timestamp (snapshot_time).
+ *
+ * Sets up a SQLite catalog with 3 snapshots, each adding one data file:
+ *   Snapshot 1 (2026-01-01): file1 (2 rows)
+ *   Snapshot 2 (2026-01-02): file2 (1 row)
+ *   Snapshot 3 (2026-01-03): file3 (1 row)
+ *
+ * At snapshot 1: 1 file  (2 rows)
+ * At snapshot 2: 2 files (3 rows)
+ * At snapshot 3: 3 files (4 rows)
+ */
+public class DuckLakeTimeTravelTest {
+
+    private File catalogFile;
+    private DuckLakeMetadataBackend backend;
+
+    @Before
+    public void setUp() throws Exception {
+        // Create a temp SQLite file for the catalog
+        catalogFile = File.createTempFile("ducklake_test_", ".db");
+        catalogFile.deleteOnExit();
+
+        // Set up the DuckLake schema and insert test data
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catalogFile.getAbsolutePath())) {
+            try (Statement s = conn.createStatement()) {
+                // --- DuckLake metadata tables ---
+                s.execute("CREATE TABLE ducklake_metadata ("
+                        + "key TEXT, value TEXT, scope TEXT)");
+                s.execute("CREATE TABLE ducklake_snapshot ("
+                        + "snapshot_id INTEGER PRIMARY KEY, "
+                        + "snapshot_time TEXT, "
+                        + "snapshot_changes TEXT)");
+                s.execute("CREATE TABLE ducklake_schema ("
+                        + "schema_id INTEGER PRIMARY KEY, "
+                        + "schema_name TEXT, path TEXT, path_is_relative INTEGER, "
+                        + "begin_snapshot INTEGER, end_snapshot INTEGER)");
+                s.execute("CREATE TABLE ducklake_table ("
+                        + "table_id INTEGER PRIMARY KEY, "
+                        + "table_uuid TEXT, table_name TEXT, schema_id INTEGER, "
+                        + "path TEXT, path_is_relative INTEGER, "
+                        + "begin_snapshot INTEGER, end_snapshot INTEGER)");
+                s.execute("CREATE TABLE ducklake_column ("
+                        + "column_id INTEGER PRIMARY KEY, "
+                        + "table_id INTEGER, column_name TEXT, column_type TEXT, "
+                        + "column_order INTEGER, initial_default TEXT, default_value TEXT, "
+                        + "nulls_allowed INTEGER, parent_column INTEGER, "
+                        + "begin_snapshot INTEGER, end_snapshot INTEGER)");
+                s.execute("CREATE TABLE ducklake_data_file ("
+                        + "data_file_id INTEGER PRIMARY KEY, "
+                        + "table_id INTEGER, path TEXT, path_is_relative INTEGER, "
+                        + "file_format TEXT, record_count INTEGER, file_size_bytes INTEGER, "
+                        + "mapping_id INTEGER, partition_id INTEGER, file_order INTEGER, "
+                        + "begin_snapshot INTEGER, end_snapshot INTEGER)");
+                s.execute("CREATE TABLE ducklake_delete_file ("
+                        + "delete_file_id INTEGER PRIMARY KEY, "
+                        + "table_id INTEGER, data_file_id INTEGER, "
+                        + "path TEXT, path_is_relative INTEGER, "
+                        + "format TEXT, delete_count INTEGER, "
+                        + "begin_snapshot INTEGER, end_snapshot INTEGER)");
+
+                // --- Metadata ---
+                s.execute("INSERT INTO ducklake_metadata VALUES ('data_path', '/tmp/ducklake_data/', NULL)");
+
+                // --- 3 snapshots ---
+                s.execute("INSERT INTO ducklake_snapshot VALUES (1, '2026-01-01T00:00:00', 'create table')");
+                s.execute("INSERT INTO ducklake_snapshot VALUES (2, '2026-01-02T00:00:00', 'insert batch 2')");
+                s.execute("INSERT INTO ducklake_snapshot VALUES (3, '2026-01-03T00:00:00', 'insert batch 3')");
+
+                // --- Schema (visible from snapshot 1) ---
+                s.execute("INSERT INTO ducklake_schema VALUES (1, 'main', NULL, 0, 1, NULL)");
+
+                // --- Table (visible from snapshot 1) ---
+                s.execute("INSERT INTO ducklake_table VALUES "
+                        + "(1, 'uuid-test-1', 'test_table', 1, 'test_table/', 1, 1, NULL)");
+
+                // --- Columns (visible from snapshot 1) ---
+                s.execute("INSERT INTO ducklake_column VALUES "
+                        + "(1, 1, 'id', 'INTEGER', 0, NULL, NULL, 0, NULL, 1, NULL)");
+                s.execute("INSERT INTO ducklake_column VALUES "
+                        + "(2, 1, 'name', 'VARCHAR', 1, NULL, NULL, 1, NULL, 1, NULL)");
+
+                // --- A column added at snapshot 3 ---
+                s.execute("INSERT INTO ducklake_column VALUES "
+                        + "(3, 1, 'score', 'DOUBLE', 2, NULL, NULL, 1, NULL, 3, NULL)");
+
+                // --- Data files: one per snapshot ---
+                s.execute("INSERT INTO ducklake_data_file VALUES "
+                        + "(1, 1, 'file1.parquet', 1, 'PARQUET', 2, 1000, NULL, NULL, 0, 1, NULL)");
+                s.execute("INSERT INTO ducklake_data_file VALUES "
+                        + "(2, 1, 'file2.parquet', 1, 'PARQUET', 1, 500,  NULL, NULL, 1, 2, NULL)");
+                s.execute("INSERT INTO ducklake_data_file VALUES "
+                        + "(3, 1, 'file3.parquet', 1, 'PARQUET', 1, 500,  NULL, NULL, 2, 3, NULL)");
+            }
+        }
+
+        backend = new DuckLakeMetadataBackend(catalogFile.getAbsolutePath(), null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (backend != null) {
+            backend.close();
+        }
+        if (catalogFile != null) {
+            catalogFile.delete();
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Snapshot query tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetSnapshotAtVersion() throws Exception {
+        SnapshotInfo s1 = backend.getSnapshotAtVersion(1);
+        assertNotNull(s1);
+        assertEquals(1, s1.snapshotId);
+        assertEquals("2026-01-01T00:00:00", s1.snapshotTime);
+        assertEquals("create table", s1.changes);
+
+        SnapshotInfo s2 = backend.getSnapshotAtVersion(2);
+        assertNotNull(s2);
+        assertEquals(2, s2.snapshotId);
+        assertEquals("2026-01-02T00:00:00", s2.snapshotTime);
+
+        SnapshotInfo s3 = backend.getSnapshotAtVersion(3);
+        assertNotNull(s3);
+        assertEquals(3, s3.snapshotId);
+    }
+
+    @Test
+    public void testGetSnapshotAtVersionNotFound() throws Exception {
+        SnapshotInfo missing = backend.getSnapshotAtVersion(999);
+        assertNull("Non-existent version should return null", missing);
+    }
+
+    @Test
+    public void testGetSnapshotAtTime() throws Exception {
+        // Exact match
+        SnapshotInfo snap = backend.getSnapshotAtTime("2026-01-02T00:00:00");
+        assertNotNull(snap);
+        assertEquals(2, snap.snapshotId);
+
+        // Between snapshot 2 and 3 -> should return snapshot 2
+        SnapshotInfo between = backend.getSnapshotAtTime("2026-01-02T12:00:00");
+        assertNotNull(between);
+        assertEquals(2, between.snapshotId);
+
+        // After all snapshots -> should return snapshot 3
+        SnapshotInfo after = backend.getSnapshotAtTime("2026-12-31T23:59:59");
+        assertNotNull(after);
+        assertEquals(3, after.snapshotId);
+    }
+
+    @Test
+    public void testGetSnapshotAtTimeBeforeAll() throws Exception {
+        // Before any snapshot exists -> should return null
+        SnapshotInfo tooEarly = backend.getSnapshotAtTime("2020-01-01T00:00:00");
+        assertNull("Timestamp before all snapshots should return null", tooEarly);
+    }
+
+    @Test
+    public void testListSnapshots() throws Exception {
+        List<SnapshotInfo> snapshots = backend.listSnapshots();
+        assertEquals(3, snapshots.size());
+        assertEquals(1, snapshots.get(0).snapshotId);
+        assertEquals(2, snapshots.get(1).snapshotId);
+        assertEquals(3, snapshots.get(2).snapshotId);
+        assertEquals("2026-01-01T00:00:00", snapshots.get(0).snapshotTime);
+        assertEquals("2026-01-02T00:00:00", snapshots.get(1).snapshotTime);
+        assertEquals("2026-01-03T00:00:00", snapshots.get(2).snapshotTime);
+    }
+
+    // ---------------------------------------------------------------
+    // resolveSnapshotId tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testResolveSnapshotIdDefault() throws Exception {
+        // Neither version nor time -> latest (snapshot 3)
+        long id = backend.resolveSnapshotId(null, null);
+        assertEquals(3, id);
+    }
+
+    @Test
+    public void testResolveSnapshotIdByVersion() throws Exception {
+        long id = backend.resolveSnapshotId("2", null);
+        assertEquals(2, id);
+    }
+
+    @Test
+    public void testResolveSnapshotIdByTime() throws Exception {
+        long id = backend.resolveSnapshotId(null, "2026-01-01T12:00:00");
+        assertEquals(1, id);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveSnapshotIdMutualExclusion() throws Exception {
+        backend.resolveSnapshotId("1", "2026-01-01T00:00:00");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveSnapshotIdInvalidVersion() throws Exception {
+        backend.resolveSnapshotId("999", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveSnapshotIdNonNumericVersion() throws Exception {
+        backend.resolveSnapshotId("abc", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveSnapshotIdTimestampTooEarly() throws Exception {
+        backend.resolveSnapshotId(null, "2020-01-01T00:00:00");
+    }
+
+    // ---------------------------------------------------------------
+    // Data file visibility at different snapshots
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetDataFilesAtSnapshot1() throws Exception {
+        List<DataFileInfo> files = backend.getDataFiles(1, 1);
+        assertEquals("Snapshot 1 should have 1 data file", 1, files.size());
+        assertEquals("file1.parquet", files.get(0).path);
+        assertEquals(2, files.get(0).recordCount);
+    }
+
+    @Test
+    public void testGetDataFilesAtSnapshot2() throws Exception {
+        List<DataFileInfo> files = backend.getDataFiles(1, 2);
+        assertEquals("Snapshot 2 should have 2 data files", 2, files.size());
+        assertEquals("file1.parquet", files.get(0).path);
+        assertEquals("file2.parquet", files.get(1).path);
+    }
+
+    @Test
+    public void testGetDataFilesAtSnapshot3() throws Exception {
+        List<DataFileInfo> files = backend.getDataFiles(1, 3);
+        assertEquals("Snapshot 3 should have 3 data files", 3, files.size());
+        assertEquals("file1.parquet", files.get(0).path);
+        assertEquals("file2.parquet", files.get(1).path);
+        assertEquals("file3.parquet", files.get(2).path);
+    }
+
+    @Test
+    public void testGetDataFilesDefaultIsLatest() throws Exception {
+        // No snapshot specified -> should use current (latest = 3)
+        List<DataFileInfo> files = backend.getDataFiles(1);
+        assertEquals("Default (latest) should have 3 data files", 3, files.size());
+    }
+
+    // ---------------------------------------------------------------
+    // Column visibility at different snapshots (schema evolution)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetColumnsAtSnapshot1() throws Exception {
+        List<ColumnInfo> cols = backend.getColumns(1, 1);
+        assertEquals("Snapshot 1 should have 2 columns", 2, cols.size());
+        assertEquals("id", cols.get(0).name);
+        assertEquals("name", cols.get(1).name);
+    }
+
+    @Test
+    public void testGetColumnsAtSnapshot2() throws Exception {
+        List<ColumnInfo> cols = backend.getColumns(1, 2);
+        assertEquals("Snapshot 2 should still have 2 columns", 2, cols.size());
+    }
+
+    @Test
+    public void testGetColumnsAtSnapshot3() throws Exception {
+        // Column 'score' was added at snapshot 3
+        List<ColumnInfo> cols = backend.getColumns(1, 3);
+        assertEquals("Snapshot 3 should have 3 columns (score added)", 3, cols.size());
+        assertEquals("id", cols.get(0).name);
+        assertEquals("name", cols.get(1).name);
+        assertEquals("score", cols.get(2).name);
+    }
+
+    // ---------------------------------------------------------------
+    // Table visibility at snapshot
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetTableAtSnapshot() throws Exception {
+        TableInfo t = backend.getTable("test_table", "main", 1);
+        assertNotNull("Table should be visible at snapshot 1", t);
+        assertEquals(1, t.tableId);
+        assertEquals("test_table", t.name);
+    }
+
+    @Test
+    public void testGetTableAtSnapshotBeforeCreation() throws Exception {
+        // Table was created at snapshot 1, so snapshot 0 should not find it
+        TableInfo t = backend.getTable("test_table", "main", 0);
+        assertNull("Table should not be visible before it was created", t);
+    }
+}


### PR DESCRIPTION
## Summary

Adds time travel support to the DuckLake Spark connector. Users can read tables at specific historical snapshots using either a version number or a timestamp.

```java
// Read at version 3
spark.read.format("ducklake")
  .option("catalog", "/path/to/catalog.ducklake")
  .option("table", "my_table")
  .option("snapshot_version", 3)
  .load()

// Read at timestamp
spark.read.format("ducklake")
  .option("catalog", "/path/to/catalog.ducklake")
  .option("table", "my_table")
  .option("snapshot_time", "2026-01-01T00:00:00")
  .load()
```

## Changes

### `DuckLakeMetadataBackend`
- **`getSnapshotAtVersion(long version)`** — query `ducklake_snapshot` for snapshot at given version
- **`getSnapshotAtTime(String timestamp)`** — find latest snapshot at or before timestamp
- **`listSnapshots()`** — list all snapshots ordered by version
- **`resolveSnapshotId(version, time)`** — resolve version/time options to a snapshot ID, with validation
- Refactored `getTable(name, schema)` and `getDeleteFiles()` to delegate to snapshot-aware overloads
- New `SnapshotInfo` data class

### `DuckLakeDataSource`
- `inferSchema()` now resolves the snapshot and uses it for table lookup and column retrieval (supports schema evolution across snapshots)

### `DuckLakeScan`
- `planInputPartitions()` threads the resolved snapshot through `getDataFiles()`, `getColumns()`, and `getDeleteFiles()` so all metadata queries target the correct historical state

### Validation
- `snapshot_version` and `snapshot_time` are mutually exclusive
- Non-existent version → clear error
- Timestamp before all snapshots → clear error
- Non-numeric version string → rejected

## Tests

21 new tests in `DuckLakeTimeTravelTest`:
- Snapshot lookup by version and timestamp
- `listSnapshots()` ordering
- `resolveSnapshotId()` for default, by-version, by-time, and all error cases
- Data file visibility at each snapshot (1 file → 2 files → 3 files)
- Column visibility across snapshots (schema evolution: `score` column added at snapshot 3)
- Table visibility before/after creation

All 34 tests pass (13 existing + 21 new).

Refs: #1