### PR TITLE
feat: Basic Write Support (append & overwrite)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
+                <configuration>
+                    <argLine>
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                        --add-opens=java.base/java.net=ALL-UNNAMED
+                        --add-opens=java.base/java.nio=ALL-UNNAMED
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                        --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+                        --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+                        --add-opens=java.base/sun.security.action=ALL-UNNAMED
+                        --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+                        --add-opens=java.base/java.math=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/ducklake/spark/DuckLakeDataSource.java
+++ b/src/main/java/io/ducklake/spark/DuckLakeDataSource.java
@@ -1,12 +1,15 @@
 package io.ducklake.spark;
 
 import io.ducklake.spark.reader.DuckLakeScanBuilder;
+import io.ducklake.spark.writer.DuckLakeWriteBuilder;
 import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
 import io.ducklake.spark.util.DuckLakeTypeMapping;
 
 import org.apache.spark.sql.connector.catalog.*;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
@@ -23,6 +26,7 @@ import java.util.*;
  *     .load()
  */
 public class DuckLakeDataSource implements TableProvider {
+
 
     @Override
     public StructType inferSchema(CaseInsensitiveStringMap options) {
@@ -73,7 +77,7 @@ public class DuckLakeDataSource implements TableProvider {
     // Inner Table class implementing SupportsRead
     // ---------------------------------------------------------------
 
-    static class DuckLakeTable implements Table, SupportsRead {
+    static class DuckLakeTable implements Table, SupportsRead, SupportsWrite {
         private final StructType schema;
         private final CaseInsensitiveStringMap options;
 
@@ -95,7 +99,9 @@ public class DuckLakeDataSource implements TableProvider {
         @Override
         public Set<TableCapability> capabilities() {
             return new HashSet<>(Arrays.asList(
-                    TableCapability.BATCH_READ
+                    TableCapability.BATCH_READ,
+                    TableCapability.BATCH_WRITE,
+                    TableCapability.TRUNCATE
             ));
         }
 
@@ -105,6 +111,13 @@ public class DuckLakeDataSource implements TableProvider {
             Map<String, String> merged = new HashMap<>(this.options.asCaseSensitiveMap());
             merged.putAll(options.asCaseSensitiveMap());
             return new DuckLakeScanBuilder(schema, new CaseInsensitiveStringMap(merged));
+        }
+
+        @Override
+        public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
+            Map<String, String> merged = new HashMap<>(this.options.asCaseSensitiveMap());
+            merged.putAll(info.options().asCaseSensitiveMap());
+            return new DuckLakeWriteBuilder(info.schema(), new CaseInsensitiveStringMap(merged));
         }
     }
 }

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
@@ -390,6 +390,171 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
     }
 
     // ---------------------------------------------------------------
+    // Write operations
+    // ---------------------------------------------------------------
+
+    /** Begin a transaction on the underlying connection. */
+    public void beginTransaction() throws SQLException {
+        getConnection().setAutoCommit(false);
+    }
+
+    /** Commit the current transaction. */
+    public void commitTransaction() throws SQLException {
+        getConnection().commit();
+        getConnection().setAutoCommit(true);
+    }
+
+    /** Rollback the current transaction. */
+    public void rollbackTransaction() throws SQLException {
+        try {
+            getConnection().rollback();
+        } finally {
+            getConnection().setAutoCommit(true);
+        }
+    }
+
+    /** Get snapshot metadata. */
+    public SnapshotInfo getSnapshotInfo(long snapshotId) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "SELECT schema_version, next_catalog_id, next_file_id FROM ducklake_snapshot WHERE snapshot_id = ?")) {
+            ps.setLong(1, snapshotId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new SnapshotInfo(
+                            rs.getLong("schema_version"),
+                            rs.getLong("next_catalog_id"),
+                            rs.getLong("next_file_id"));
+                }
+            }
+        }
+        throw new SQLException("Snapshot not found: " + snapshotId);
+    }
+
+    /** Get table-level statistics. */
+    public TableStats getTableStats(long tableId) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "SELECT record_count, next_row_id, file_size_bytes FROM ducklake_table_stats WHERE table_id = ?")) {
+            ps.setLong(1, tableId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new TableStats(
+                            rs.getLong("record_count"),
+                            rs.getLong("next_row_id"),
+                            rs.getLong("file_size_bytes"));
+                }
+            }
+        }
+        return new TableStats(0, 0, 0);
+    }
+
+    /** Check if a table has any active data files. */
+    public boolean hasDataFiles(long tableId) throws SQLException {
+        long snap = getCurrentSnapshotId();
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "SELECT 1 FROM ducklake_data_file WHERE table_id = ? " +
+                "AND begin_snapshot <= ? AND (end_snapshot IS NULL OR end_snapshot > ?) LIMIT 1")) {
+            ps.setLong(1, tableId);
+            ps.setLong(2, snap);
+            ps.setLong(3, snap);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    /** Create a new snapshot record. */
+    public void createSnapshot(long snapshotId, long schemaVersion, long nextCatalogId, long nextFileId) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id) VALUES (?, datetime('now'), ?, ?, ?)")) {
+            ps.setLong(1, snapshotId);
+            ps.setLong(2, schemaVersion);
+            ps.setLong(3, nextCatalogId);
+            ps.setLong(4, nextFileId);
+            ps.executeUpdate();
+        }
+    }
+
+    /** Insert a snapshot changes record. */
+    public void insertSnapshotChanges(long snapshotId, String changesMade, String author, String commitMessage) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "INSERT INTO ducklake_snapshot_changes (snapshot_id, changes_made, author, commit_message) VALUES (?, ?, ?, ?)")) {
+            ps.setLong(1, snapshotId);
+            ps.setString(2, changesMade);
+            ps.setString(3, author);
+            ps.setString(4, commitMessage);
+            ps.executeUpdate();
+        }
+    }
+
+    /** Insert a data file record. */
+    public void insertDataFile(long dataFileId, long tableId, long beginSnapshot, long fileOrder,
+                               String path, long recordCount, long fileSizeBytes, long rowIdStart) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "INSERT INTO ducklake_data_file (data_file_id, table_id, begin_snapshot, end_snapshot, file_order, path, path_is_relative, " +
+                "file_format, record_count, file_size_bytes, footer_size, row_id_start, partition_id, encryption_key, mapping_id, partial_max) " +
+                "VALUES (?, ?, ?, NULL, ?, ?, 1, 'PARQUET', ?, ?, 0, ?, NULL, NULL, NULL, NULL)")) {
+            ps.setLong(1, dataFileId);
+            ps.setLong(2, tableId);
+            ps.setLong(3, beginSnapshot);
+            ps.setLong(4, fileOrder);
+            ps.setString(5, path);
+            ps.setLong(6, recordCount);
+            ps.setLong(7, fileSizeBytes);
+            ps.setLong(8, rowIdStart);
+            ps.executeUpdate();
+        }
+    }
+
+    /** Insert column statistics for a data file. */
+    public void insertColumnStats(long dataFileId, long tableId, long columnId,
+                                  long valueCount, long nullCount, String minValue, String maxValue) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "INSERT INTO ducklake_file_column_stats (data_file_id, table_id, column_id, column_size_bytes, value_count, null_count, " +
+                "min_value, max_value, contains_nan, extra_stats) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, NULL, NULL)")) {
+            ps.setLong(1, dataFileId);
+            ps.setLong(2, tableId);
+            ps.setLong(3, columnId);
+            ps.setLong(4, valueCount);
+            ps.setLong(5, nullCount);
+            if (minValue != null) { ps.setString(6, minValue); } else { ps.setNull(6, java.sql.Types.VARCHAR); }
+            if (maxValue != null) { ps.setString(7, maxValue); } else { ps.setNull(7, java.sql.Types.VARCHAR); }
+            ps.executeUpdate();
+        }
+    }
+
+    /** Upsert table-level statistics. */
+    public void updateTableStats(long tableId, long recordCount, long nextRowId, long fileSizeBytes) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "UPDATE ducklake_table_stats SET record_count = ?, next_row_id = ?, file_size_bytes = ? WHERE table_id = ?")) {
+            ps.setLong(1, recordCount);
+            ps.setLong(2, nextRowId);
+            ps.setLong(3, fileSizeBytes);
+            ps.setLong(4, tableId);
+            int updated = ps.executeUpdate();
+            if (updated == 0) {
+                try (PreparedStatement insert = getConnection().prepareStatement(
+                        "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes) VALUES (?, ?, ?, ?)")) {
+                    insert.setLong(1, tableId);
+                    insert.setLong(2, recordCount);
+                    insert.setLong(3, nextRowId);
+                    insert.setLong(4, fileSizeBytes);
+                    insert.executeUpdate();
+                }
+            }
+        }
+    }
+
+    /** Mark all active data files for a table as deleted at the given snapshot. */
+    public void markDataFilesDeleted(long tableId, long snapshotId) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "UPDATE ducklake_data_file SET end_snapshot = ? WHERE table_id = ? AND end_snapshot IS NULL")) {
+            ps.setLong(1, snapshotId);
+            ps.setLong(2, tableId);
+            ps.executeUpdate();
+        }
+    }
+
+    // ---------------------------------------------------------------
     // Data classes
     // ---------------------------------------------------------------
 
@@ -502,6 +667,30 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
             this.maxValue = maxValue;
             this.nullCount = nullCount;
             this.valueCount = valueCount;
+        }
+    }
+
+    public static class SnapshotInfo {
+        public final long schemaVersion;
+        public final long nextCatalogId;
+        public final long nextFileId;
+
+        public SnapshotInfo(long schemaVersion, long nextCatalogId, long nextFileId) {
+            this.schemaVersion = schemaVersion;
+            this.nextCatalogId = nextCatalogId;
+            this.nextFileId = nextFileId;
+        }
+    }
+
+    public static class TableStats {
+        public final long recordCount;
+        public final long nextRowId;
+        public final long fileSizeBytes;
+
+        public TableStats(long recordCount, long nextRowId, long fileSizeBytes) {
+            this.recordCount = recordCount;
+            this.nextRowId = nextRowId;
+            this.fileSizeBytes = fileSizeBytes;
         }
     }
 }

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeBatchWrite.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeBatchWrite.java
@@ -1,0 +1,157 @@
+package io.ducklake.spark.writer;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+
+import org.apache.spark.sql.connector.write.*;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Manages the lifecycle of a batch write operation to a DuckLake table.
+ * Creates writer factories for executors and commits file metadata to the catalog.
+ */
+public class DuckLakeBatchWrite implements Write, BatchWrite {
+
+    private final CaseInsensitiveStringMap options;
+    private final StructType schema;
+    private final TableInfo tableInfo;
+    private final List<ColumnInfo> columns;
+    private final String dataPath;
+    private final String tablePath;
+    private final long[] columnIds;
+    private final boolean isOverwrite;
+
+    public DuckLakeBatchWrite(CaseInsensitiveStringMap options, StructType schema,
+                               TableInfo tableInfo, List<ColumnInfo> columns,
+                               String dataPath, String tablePath,
+                               long[] columnIds, boolean isOverwrite) {
+        this.options = options;
+        this.schema = schema;
+        this.tableInfo = tableInfo;
+        this.columns = columns;
+        this.dataPath = dataPath;
+        this.tablePath = tablePath;
+        this.columnIds = columnIds;
+        this.isOverwrite = isOverwrite;
+    }
+
+    @Override
+    public BatchWrite toBatch() {
+        return this;
+    }
+
+    @Override
+    public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
+        String writeBasePath = dataPath + tablePath;
+        return new DuckLakeDataWriterFactory(schema, columnIds, writeBasePath, tablePath);
+    }
+
+    @Override
+    public void commit(WriterCommitMessage[] messages) {
+        List<DuckLakeWriterCommitMessage> validMessages = new ArrayList<>();
+        for (WriterCommitMessage msg : messages) {
+            if (msg != null) {
+                DuckLakeWriterCommitMessage dlMsg = (DuckLakeWriterCommitMessage) msg;
+                if (dlMsg.recordCount > 0) {
+                    validMessages.add(dlMsg);
+                }
+            }
+        }
+
+        if (validMessages.isEmpty() && !isOverwrite) {
+            return;
+        }
+
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            backend.beginTransaction();
+            try {
+                long currentSnap = backend.getCurrentSnapshotId();
+                SnapshotInfo snapInfo = backend.getSnapshotInfo(currentSnap);
+
+                long newSnap = currentSnap + 1;
+                long nextFileId = snapInfo.nextFileId;
+                long newNextFileId = nextFileId + validMessages.size();
+
+                // Create new snapshot
+                backend.createSnapshot(newSnap, snapInfo.schemaVersion,
+                        snapInfo.nextCatalogId, newNextFileId);
+
+                // If overwrite, mark existing files as deleted
+                if (isOverwrite) {
+                    backend.markDataFilesDeleted(tableInfo.tableId, newSnap);
+                }
+
+                // Get current table stats
+                TableStats tableStats = backend.getTableStats(tableInfo.tableId);
+                long rowIdStart = isOverwrite ? 0 : tableStats.nextRowId;
+                long totalRecordCount = isOverwrite ? 0 : tableStats.recordCount;
+                long totalFileSize = isOverwrite ? 0 : tableStats.fileSizeBytes;
+
+                // Insert data files and column stats
+                long fileId = nextFileId;
+                int fileOrder = 0;
+                for (DuckLakeWriterCommitMessage msg : validMessages) {
+                    backend.insertDataFile(fileId, tableInfo.tableId, newSnap, fileOrder,
+                            msg.relativePath, msg.recordCount, msg.fileSize, rowIdStart);
+
+                    for (DuckLakeWriterCommitMessage.ColumnStats stats : msg.columnStats) {
+                        backend.insertColumnStats(fileId, tableInfo.tableId, stats.columnId,
+                                stats.valueCount, stats.nullCount, stats.minValue, stats.maxValue);
+                    }
+
+                    rowIdStart += msg.recordCount;
+                    totalRecordCount += msg.recordCount;
+                    totalFileSize += msg.fileSize;
+                    fileId++;
+                    fileOrder++;
+                }
+
+                // Update table stats
+                backend.updateTableStats(tableInfo.tableId, totalRecordCount, rowIdStart, totalFileSize);
+
+                // Record snapshot changes
+                String changes = "inserted_into_table:" + tableInfo.tableId;
+                if (isOverwrite) {
+                    changes = "deleted_from_table:" + tableInfo.tableId + "," + changes;
+                }
+                backend.insertSnapshotChanges(newSnap, changes, "ducklake-spark", "Spark write");
+
+                backend.commitTransaction();
+            } catch (Exception e) {
+                try {
+                    backend.rollbackTransaction();
+                } catch (SQLException rollbackEx) {
+                    e.addSuppressed(rollbackEx);
+                }
+                throw e;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to commit DuckLake write", e);
+        }
+    }
+
+    @Override
+    public void abort(WriterCommitMessage[] messages) {
+        for (WriterCommitMessage msg : messages) {
+            if (msg != null) {
+                DuckLakeWriterCommitMessage dlMsg = (DuckLakeWriterCommitMessage) msg;
+                try {
+                    new File(dlMsg.absolutePath).delete();
+                } catch (Exception e) {
+                    // Best effort cleanup
+                }
+            }
+        }
+    }
+
+    private DuckLakeMetadataBackend createBackend() {
+        String catalog = options.get("catalog");
+        String dp = options.getOrDefault("data_path", null);
+        return new DuckLakeMetadataBackend(catalog, dp);
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeDataWriter.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeDataWriter.java
@@ -1,0 +1,350 @@
+package io.ducklake.spark.writer;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.*;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.*;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+/**
+ * Writes InternalRow data to a Parquet file and collects column statistics.
+ * Each partition gets its own writer instance writing to a unique file.
+ */
+public class DuckLakeDataWriter implements DataWriter<InternalRow> {
+
+    private final StructType schema;
+    private final long[] columnIds;
+    private final String absolutePath;
+    private final String relativePath;
+    private final MessageType parquetSchema;
+    private final SimpleGroupFactory groupFactory;
+    private final ParquetWriter<Group> writer;
+    private final ColumnStatsAccumulator[] statsAccumulators;
+    private long recordCount = 0;
+
+    public DuckLakeDataWriter(StructType schema, long[] columnIds,
+                               String writeBasePath, String tablePath,
+                               int partitionId, long taskAttemptId) {
+        this.schema = schema;
+        this.columnIds = columnIds;
+
+        String fileName = "ducklake-" + UUID.randomUUID() + ".parquet";
+        this.relativePath = tablePath + fileName;
+        this.absolutePath = writeBasePath + fileName;
+
+        // Ensure directory exists
+        File parentDir = new File(this.absolutePath).getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+
+        this.parquetSchema = buildParquetSchema(schema, columnIds);
+        this.groupFactory = new SimpleGroupFactory(parquetSchema);
+
+        // Initialize stats accumulators
+        this.statsAccumulators = new ColumnStatsAccumulator[schema.fields().length];
+        for (int i = 0; i < schema.fields().length; i++) {
+            statsAccumulators[i] = new ColumnStatsAccumulator(schema.fields()[i].dataType());
+        }
+
+        try {
+            Configuration conf = new Configuration();
+            this.writer = ExampleParquetWriter.builder(new Path(this.absolutePath))
+                    .withType(parquetSchema)
+                    .withConf(conf)
+                    .withWriteMode(ParquetFileWriter.Mode.CREATE)
+                    .build();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create Parquet writer at: " + absolutePath, e);
+        }
+    }
+
+    @Override
+    public void write(InternalRow row) throws IOException {
+        Group group = groupFactory.newGroup();
+        for (int i = 0; i < schema.fields().length; i++) {
+            DataType type = schema.fields()[i].dataType();
+            if (row.isNullAt(i)) {
+                statsAccumulators[i].addNull();
+                continue;
+            }
+            Object value = writeField(group, i, row, i, type);
+            statsAccumulators[i].addValue(value);
+        }
+        writer.write(group);
+        recordCount++;
+    }
+
+    @Override
+    public WriterCommitMessage commit() throws IOException {
+        writer.close();
+
+        long fileSize = new File(absolutePath).length();
+
+        List<DuckLakeWriterCommitMessage.ColumnStats> colStats = new ArrayList<>();
+        for (int i = 0; i < schema.fields().length; i++) {
+            ColumnStatsAccumulator acc = statsAccumulators[i];
+            colStats.add(new DuckLakeWriterCommitMessage.ColumnStats(
+                    columnIds[i],
+                    acc.getMinString(),
+                    acc.getMaxString(),
+                    acc.nullCount,
+                    acc.valueCount));
+        }
+
+        return new DuckLakeWriterCommitMessage(absolutePath, relativePath,
+                recordCount, fileSize, colStats);
+    }
+
+    @Override
+    public void abort() throws IOException {
+        try {
+            writer.close();
+        } catch (Exception e) {
+            // Ignore close errors on abort
+        }
+        new File(absolutePath).delete();
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Called after commit or abort
+    }
+
+    // ---------------------------------------------------------------
+    // Parquet schema construction
+    // ---------------------------------------------------------------
+
+    private static MessageType buildParquetSchema(StructType sparkSchema, long[] columnIds) {
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < sparkSchema.fields().length; i++) {
+            StructField field = sparkSchema.fields()[i];
+            int fieldId = (int) columnIds[i];
+            builder.addField(sparkTypeToParquetType(field.name(), field.dataType(), field.nullable(), fieldId));
+        }
+        return builder.named("spark_schema");
+    }
+
+    private static org.apache.parquet.schema.Type sparkTypeToParquetType(
+            String name, DataType type, boolean nullable, int fieldId) {
+        if (type instanceof BooleanType) {
+            return primitive(nullable, PrimitiveTypeName.BOOLEAN, null, fieldId, name);
+        } else if (type instanceof ByteType || type instanceof ShortType || type instanceof IntegerType) {
+            return primitive(nullable, PrimitiveTypeName.INT32, null, fieldId, name);
+        } else if (type instanceof LongType) {
+            return primitive(nullable, PrimitiveTypeName.INT64, null, fieldId, name);
+        } else if (type instanceof FloatType) {
+            return primitive(nullable, PrimitiveTypeName.FLOAT, null, fieldId, name);
+        } else if (type instanceof DoubleType) {
+            return primitive(nullable, PrimitiveTypeName.DOUBLE, null, fieldId, name);
+        } else if (type instanceof StringType) {
+            return primitive(nullable, PrimitiveTypeName.BINARY,
+                    LogicalTypeAnnotation.stringType(), fieldId, name);
+        } else if (type instanceof BinaryType) {
+            return primitive(nullable, PrimitiveTypeName.BINARY, null, fieldId, name);
+        } else if (type instanceof DateType) {
+            return primitive(nullable, PrimitiveTypeName.INT32,
+                    LogicalTypeAnnotation.dateType(), fieldId, name);
+        } else if (type instanceof TimestampType) {
+            return primitive(nullable, PrimitiveTypeName.INT64,
+                    LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS),
+                    fieldId, name);
+        } else if (type instanceof DecimalType) {
+            DecimalType dt = (DecimalType) type;
+            if (dt.precision() <= 9) {
+                return primitive(nullable, PrimitiveTypeName.INT32,
+                        LogicalTypeAnnotation.decimalType(dt.scale(), dt.precision()), fieldId, name);
+            } else if (dt.precision() <= 18) {
+                return primitive(nullable, PrimitiveTypeName.INT64,
+                        LogicalTypeAnnotation.decimalType(dt.scale(), dt.precision()), fieldId, name);
+            } else {
+                int byteLen = computeDecimalByteLength(dt.precision());
+                if (nullable) {
+                    return Types.optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(byteLen)
+                            .as(LogicalTypeAnnotation.decimalType(dt.scale(), dt.precision()))
+                            .id(fieldId).named(name);
+                } else {
+                    return Types.required(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(byteLen)
+                            .as(LogicalTypeAnnotation.decimalType(dt.scale(), dt.precision()))
+                            .id(fieldId).named(name);
+                }
+            }
+        }
+        // Fallback: store as string
+        return primitive(nullable, PrimitiveTypeName.BINARY,
+                LogicalTypeAnnotation.stringType(), fieldId, name);
+    }
+
+    private static PrimitiveType primitive(boolean nullable, PrimitiveTypeName typeName,
+                                            LogicalTypeAnnotation logicalType, int fieldId, String name) {
+        if (logicalType != null) {
+            return nullable
+                    ? Types.optional(typeName).as(logicalType).id(fieldId).named(name)
+                    : Types.required(typeName).as(logicalType).id(fieldId).named(name);
+        } else {
+            return nullable
+                    ? Types.optional(typeName).id(fieldId).named(name)
+                    : Types.required(typeName).id(fieldId).named(name);
+        }
+    }
+
+    private static int computeDecimalByteLength(int precision) {
+        return (int) Math.ceil(Math.log(Math.pow(10, precision)) / Math.log(2) / 8.0) + 1;
+    }
+
+    // ---------------------------------------------------------------
+    // InternalRow → Parquet Group conversion
+    // ---------------------------------------------------------------
+
+    private Object writeField(Group group, int fieldIndex, InternalRow row, int ordinal, DataType type) {
+        if (type instanceof BooleanType) {
+            boolean v = row.getBoolean(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof ByteType) {
+            byte v = row.getByte(ordinal);
+            group.add(fieldIndex, (int) v);
+            return (int) v;
+        } else if (type instanceof ShortType) {
+            short v = row.getShort(ordinal);
+            group.add(fieldIndex, (int) v);
+            return (int) v;
+        } else if (type instanceof IntegerType) {
+            int v = row.getInt(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof LongType) {
+            long v = row.getLong(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof FloatType) {
+            float v = row.getFloat(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof DoubleType) {
+            double v = row.getDouble(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof StringType) {
+            String v = row.getUTF8String(ordinal).toString();
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof BinaryType) {
+            byte[] v = row.getBinary(ordinal);
+            group.add(fieldIndex, Binary.fromReusedByteArray(v));
+            return null; // skip binary stats
+        } else if (type instanceof DateType) {
+            int v = row.getInt(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof TimestampType) {
+            long v = row.getLong(ordinal);
+            group.add(fieldIndex, v);
+            return v;
+        } else if (type instanceof DecimalType) {
+            DecimalType dt = (DecimalType) type;
+            org.apache.spark.sql.types.Decimal dec = row.getDecimal(ordinal, dt.precision(), dt.scale());
+            if (dt.precision() <= 9) {
+                int v = (int) dec.toUnscaledLong();
+                group.add(fieldIndex, v);
+                return v;
+            } else if (dt.precision() <= 18) {
+                long v = dec.toUnscaledLong();
+                group.add(fieldIndex, v);
+                return v;
+            } else {
+                byte[] unscaled = dec.toJavaBigDecimal().unscaledValue().toByteArray();
+                int byteLen = computeDecimalByteLength(dt.precision());
+                byte[] padded = new byte[byteLen];
+                if (unscaled[0] < 0) {
+                    Arrays.fill(padded, (byte) 0xFF);
+                }
+                System.arraycopy(unscaled, 0, padded, padded.length - unscaled.length, unscaled.length);
+                group.add(fieldIndex, Binary.fromConstantByteArray(padded));
+                return null; // skip stats for large decimals
+            }
+        }
+        // Fallback: write as string
+        String v = row.get(ordinal, type).toString();
+        group.add(fieldIndex, v);
+        return v;
+    }
+
+    // ---------------------------------------------------------------
+    // Column statistics tracking
+    // ---------------------------------------------------------------
+
+    private static class ColumnStatsAccumulator {
+        final DataType dataType;
+        long nullCount = 0;
+        long valueCount = 0;
+        Comparable<?> minValue = null;
+        Comparable<?> maxValue = null;
+
+        ColumnStatsAccumulator(DataType dataType) {
+            this.dataType = dataType;
+        }
+
+        void addNull() {
+            nullCount++;
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        void addValue(Object value) {
+            if (value == null) {
+                // Binary or unsupported type - track count only
+                valueCount++;
+                return;
+            }
+            valueCount++;
+            Comparable comp = (Comparable) value;
+            if (minValue == null || comp.compareTo(minValue) < 0) {
+                minValue = comp;
+            }
+            if (maxValue == null || comp.compareTo(maxValue) > 0) {
+                maxValue = comp;
+            }
+        }
+
+        String getMinString() {
+            return valueToString(minValue, dataType);
+        }
+
+        String getMaxString() {
+            return valueToString(maxValue, dataType);
+        }
+
+        private static String valueToString(Object value, DataType type) {
+            if (value == null) return null;
+            if (type instanceof DateType) {
+                int days = (Integer) value;
+                return LocalDate.ofEpochDay(days).toString();
+            }
+            if (type instanceof TimestampType) {
+                long micros = (Long) value;
+                Instant instant = Instant.ofEpochSecond(micros / 1_000_000, (micros % 1_000_000) * 1000);
+                LocalDateTime dt = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+                return dt.toString().replace('T', ' ');
+            }
+            return value.toString();
+        }
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeDataWriterFactory.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeDataWriterFactory.java
@@ -1,0 +1,35 @@
+package io.ducklake.spark.writer;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.types.StructType;
+
+import java.io.Serializable;
+
+/**
+ * Factory for creating partition-level Parquet writers.
+ * Serialized and sent to executors by Spark.
+ */
+public class DuckLakeDataWriterFactory implements DataWriterFactory, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final StructType schema;
+    private final long[] columnIds;
+    private final String writeBasePath;
+    private final String tablePath;
+
+    public DuckLakeDataWriterFactory(StructType schema, long[] columnIds,
+                                     String writeBasePath, String tablePath) {
+        this.schema = schema;
+        this.columnIds = columnIds;
+        this.writeBasePath = writeBasePath;
+        this.tablePath = tablePath;
+    }
+
+    @Override
+    public DataWriter<InternalRow> createWriter(int partitionId, long taskAttemptId) {
+        return new DuckLakeDataWriter(schema, columnIds, writeBasePath, tablePath,
+                partitionId, taskAttemptId);
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeWriteBuilder.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeWriteBuilder.java
@@ -1,0 +1,88 @@
+package io.ducklake.spark.writer;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+
+import org.apache.spark.sql.connector.write.*;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Builds write plans for DuckLake tables.
+ * Supports append (default) and truncate-overwrite modes.
+ */
+public class DuckLakeWriteBuilder implements WriteBuilder, SupportsTruncate {
+
+    private final StructType schema;
+    private final CaseInsensitiveStringMap options;
+    private boolean isOverwrite = false;
+
+    public DuckLakeWriteBuilder(StructType schema, CaseInsensitiveStringMap options) {
+        this.schema = schema;
+        this.options = options;
+    }
+
+    @Override
+    public WriteBuilder truncate() {
+        this.isOverwrite = true;
+        return this;
+    }
+
+    @Override
+    public Write build() {
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            String tableName = options.get("table");
+            String schemaName = options.getOrDefault("schema", "main");
+
+            TableInfo tableInfo = backend.getTable(tableName, schemaName);
+            if (tableInfo == null) {
+                throw new RuntimeException("Table not found: " + schemaName + "." + tableName);
+            }
+
+            String dataPath = backend.getDataPath();
+            if (!dataPath.endsWith("/")) dataPath += "/";
+
+            List<ColumnInfo> columns = backend.getColumns(tableInfo.tableId);
+
+            // Resolve table path (relative to data path)
+            String tablePath = tableInfo.path;
+            if (tablePath != null && !tablePath.isEmpty()) {
+                if (!tablePath.endsWith("/")) tablePath += "/";
+            } else {
+                tablePath = "";
+            }
+
+            // Map Spark schema field positions to DuckLake column IDs
+            long[] columnIds = new long[schema.fields().length];
+            for (int i = 0; i < schema.fields().length; i++) {
+                String sparkColName = schema.fields()[i].name();
+                boolean found = false;
+                for (ColumnInfo col : columns) {
+                    if (col.name.equalsIgnoreCase(sparkColName)) {
+                        columnIds[i] = col.columnId;
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    throw new RuntimeException("Column '" + sparkColName +
+                            "' not found in DuckLake table " + schemaName + "." + tableName);
+                }
+            }
+
+            return new DuckLakeBatchWrite(options, schema, tableInfo, columns,
+                    dataPath, tablePath, columnIds, isOverwrite);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to build DuckLake write plan", e);
+        }
+    }
+
+    private DuckLakeMetadataBackend createBackend() {
+        String catalog = options.get("catalog");
+        String dataPath = options.getOrDefault("data_path", null);
+        return new DuckLakeMetadataBackend(catalog, dataPath);
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeWriterCommitMessage.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeWriterCommitMessage.java
@@ -1,0 +1,49 @@
+package io.ducklake.spark.writer;
+
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Commit message from a single partition writer.
+ * Contains the written file path, record count, and per-column statistics.
+ */
+public class DuckLakeWriterCommitMessage implements WriterCommitMessage {
+    private static final long serialVersionUID = 1L;
+
+    public final String absolutePath;
+    public final String relativePath;
+    public final long recordCount;
+    public final long fileSize;
+    public final List<ColumnStats> columnStats;
+
+    public DuckLakeWriterCommitMessage(String absolutePath, String relativePath,
+                                        long recordCount, long fileSize,
+                                        List<ColumnStats> columnStats) {
+        this.absolutePath = absolutePath;
+        this.relativePath = relativePath;
+        this.recordCount = recordCount;
+        this.fileSize = fileSize;
+        this.columnStats = columnStats;
+    }
+
+    public static class ColumnStats implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        public final long columnId;
+        public final String minValue;
+        public final String maxValue;
+        public final long nullCount;
+        public final long valueCount;
+
+        public ColumnStats(long columnId, String minValue, String maxValue,
+                           long nullCount, long valueCount) {
+            this.columnId = columnId;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+            this.nullCount = nullCount;
+            this.valueCount = valueCount;
+        }
+    }
+}

--- a/src/test/java/io/ducklake/spark/DuckLakeWriteTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeWriteTest.java
@@ -1,0 +1,436 @@
+package io.ducklake.spark;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.junit.*;
+
+import java.io.File;
+import java.nio.file.*;
+import java.sql.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for DuckLake write support.
+ * Sets up a SQLite-based DuckLake catalog and writes/reads data via Spark.
+ */
+public class DuckLakeWriteTest {
+
+    private static SparkSession spark;
+    private String tempDir;
+    private String catalogPath;
+    private String dataPath;
+
+    @BeforeClass
+    public static void setupSpark() {
+        spark = SparkSession.builder()
+                .master("local[2]")
+                .appName("DuckLakeWriteTest")
+                .config("spark.ui.enabled", "false")
+                .config("spark.driver.host", "localhost")
+                .getOrCreate();
+    }
+
+    @AfterClass
+    public static void tearDownSpark() {
+        if (spark != null) {
+            spark.stop();
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        tempDir = Files.createTempDirectory("ducklake-write-test-").toString();
+        dataPath = tempDir + "/data/";
+        new File(dataPath).mkdirs();
+        new File(dataPath + "main/test_table/").mkdirs();
+        catalogPath = tempDir + "/test.ducklake";
+        createCatalog(catalogPath, dataPath,
+                "test_table", "main/test_table/",
+                new String[]{"id", "name", "value"},
+                new String[]{"INTEGER", "VARCHAR", "DOUBLE"},
+                new long[]{0, 1, 2});
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        deleteRecursive(new File(tempDir));
+    }
+
+    // ---------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testBasicAppendWrite() {
+        // Write data
+        StructType writeSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        List<Row> data = Arrays.asList(
+                RowFactory.create(1, "alice", 10.5),
+                RowFactory.create(2, "bob", 20.3),
+                RowFactory.create(3, "charlie", 30.7));
+
+        Dataset<Row> df = spark.createDataFrame(data, writeSchema);
+        df.write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append)
+                .save();
+
+        // Read back
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .load();
+
+        assertEquals(3, result.count());
+        List<Row> rows = result.orderBy("id").collectAsList();
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals("alice", rows.get(0).getString(1));
+        assertEquals(10.5, rows.get(0).getDouble(2), 0.001);
+    }
+
+    @Test
+    public void testMultipleAppends() {
+        StructType writeSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        // First append
+        List<Row> data1 = Arrays.asList(
+                RowFactory.create(1, "alice", 10.0),
+                RowFactory.create(2, "bob", 20.0));
+        spark.createDataFrame(data1, writeSchema).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append).save();
+
+        // Second append
+        List<Row> data2 = Arrays.asList(
+                RowFactory.create(3, "charlie", 30.0),
+                RowFactory.create(4, "diana", 40.0));
+        spark.createDataFrame(data2, writeSchema).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append).save();
+
+        // Read back
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table").load();
+
+        assertEquals(4, result.count());
+        List<Row> rows = result.orderBy("id").collectAsList();
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(4, rows.get(3).getInt(0));
+    }
+
+    @Test
+    public void testOverwriteMode() {
+        StructType writeSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        // First write
+        List<Row> data1 = Arrays.asList(
+                RowFactory.create(1, "alice", 10.0),
+                RowFactory.create(2, "bob", 20.0));
+        spark.createDataFrame(data1, writeSchema).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append).save();
+
+        // Overwrite
+        List<Row> data2 = Arrays.asList(
+                RowFactory.create(100, "new_data", 99.9));
+        spark.createDataFrame(data2, writeSchema).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Overwrite).save();
+
+        // Read back — should only see overwritten data
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table").load();
+
+        assertEquals(1, result.count());
+        Row row = result.collectAsList().get(0);
+        assertEquals(100, row.getInt(0));
+        assertEquals("new_data", row.getString(1));
+    }
+
+    @Test
+    public void testTypeRoundTrip() throws Exception {
+        // Create a table with various types
+        String catPath2 = tempDir + "/types.ducklake";
+        String dp2 = tempDir + "/types_data/";
+        new File(dp2).mkdirs();
+        new File(dp2 + "main/types_table/").mkdirs();
+
+        createCatalog(catPath2, dp2, "types_table", "main/types_table/",
+                new String[]{"bool_col", "byte_col", "short_col", "int_col", "long_col",
+                             "float_col", "double_col", "string_col"},
+                new String[]{"BOOLEAN", "TINYINT", "SMALLINT", "INTEGER", "BIGINT",
+                             "FLOAT", "DOUBLE", "VARCHAR"},
+                new long[]{0, 1, 2, 3, 4, 5, 6, 7});
+
+        StructType writeSchema = new StructType()
+                .add("bool_col", DataTypes.BooleanType, true)
+                .add("byte_col", DataTypes.ByteType, true)
+                .add("short_col", DataTypes.ShortType, true)
+                .add("int_col", DataTypes.IntegerType, true)
+                .add("long_col", DataTypes.LongType, true)
+                .add("float_col", DataTypes.FloatType, true)
+                .add("double_col", DataTypes.DoubleType, true)
+                .add("string_col", DataTypes.StringType, true);
+
+        List<Row> data = Arrays.asList(
+                RowFactory.create(true, (byte) 42, (short) 1000, 100000, 9999999999L,
+                        3.14f, 2.718281828, "hello world"),
+                RowFactory.create(false, (byte) -1, (short) -100, -42, -1L,
+                        0.0f, -99.99, "test"));
+
+        spark.createDataFrame(data, writeSchema).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catPath2)
+                .option("table", "types_table")
+                .mode(SaveMode.Append).save();
+
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catPath2)
+                .option("table", "types_table").load();
+
+        assertEquals(2, result.count());
+        List<Row> rows = result.orderBy("int_col").collectAsList();
+
+        // Second row (int_col = -42)
+        Row r0 = rows.get(0);
+        assertFalse(r0.getBoolean(0));
+        assertEquals(-1, r0.getByte(1));
+        assertEquals(-100, r0.getShort(2));
+        assertEquals(-42, r0.getInt(3));
+        assertEquals(-1L, r0.getLong(4));
+        assertEquals(0.0f, r0.getFloat(5), 0.001);
+        assertEquals(-99.99, r0.getDouble(6), 0.001);
+        assertEquals("test", r0.getString(7));
+
+        // First row (int_col = 100000)
+        Row r1 = rows.get(1);
+        assertTrue(r1.getBoolean(0));
+        assertEquals(42, r1.getByte(1));
+        assertEquals(1000, r1.getShort(2));
+        assertEquals(100000, r1.getInt(3));
+        assertEquals(9999999999L, r1.getLong(4));
+        assertEquals(3.14f, r1.getFloat(5), 0.01);
+        assertEquals(2.718281828, r1.getDouble(6), 0.00001);
+        assertEquals("hello world", r1.getString(7));
+    }
+
+    @Test
+    public void testNullValues() {
+        StructType writeSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        List<Row> data = Arrays.asList(
+                RowFactory.create(1, null, 10.0),
+                RowFactory.create(2, "bob", null),
+                RowFactory.create(3, null, null));
+
+        spark.createDataFrame(data, writeSchema).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append).save();
+
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table").load();
+
+        assertEquals(3, result.count());
+        List<Row> rows = result.orderBy("id").collectAsList();
+        assertNull(rows.get(0).getString(1));
+        assertEquals(10.0, rows.get(0).getDouble(2), 0.001);
+        assertEquals("bob", rows.get(1).getString(1));
+        assertTrue(rows.get(1).isNullAt(2));
+        assertNull(rows.get(2).getString(1));
+        assertTrue(rows.get(2).isNullAt(2));
+    }
+
+    @Test
+    public void testColumnStatsRecorded() throws Exception {
+        StructType writeSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        List<Row> data = Arrays.asList(
+                RowFactory.create(1, "alice", 10.5),
+                RowFactory.create(5, null, 50.0),
+                RowFactory.create(3, "charlie", 30.0));
+
+        spark.createDataFrame(data, writeSchema).coalesce(1).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append).save();
+
+        // Verify stats in the catalog (single partition via coalesce)
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catalogPath)) {
+            // Check data file was created
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery(
+                     "SELECT SUM(record_count) as total FROM ducklake_data_file WHERE table_id = 1 AND end_snapshot IS NULL")) {
+                assertTrue("Data file should exist", rs.next());
+                assertEquals(3, rs.getLong("total"));
+            }
+
+            // Check column stats for 'id' column (column_id = 0) — aggregate across files
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT MIN(min_value) as min_v, MAX(max_value) as max_v, " +
+                    "SUM(null_count) as nulls, SUM(value_count) as vals " +
+                    "FROM ducklake_file_column_stats WHERE table_id = 1 AND column_id = 0")) {
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue("Stats for id column should exist", rs.next());
+                    assertEquals("1", rs.getString("min_v"));
+                    assertEquals("5", rs.getString("max_v"));
+                    assertEquals(0, rs.getLong("nulls"));
+                    assertEquals(3, rs.getLong("vals"));
+                }
+            }
+
+            // Check column stats for 'name' column (column_id = 1) — has 1 null
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT SUM(null_count) as nulls, SUM(value_count) as vals " +
+                    "FROM ducklake_file_column_stats WHERE table_id = 1 AND column_id = 1")) {
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue("Stats for name column should exist", rs.next());
+                    assertEquals(1, rs.getLong("nulls"));
+                    assertEquals(2, rs.getLong("vals"));
+                }
+            }
+
+            // Check table stats updated
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT record_count, next_row_id FROM ducklake_table_stats WHERE table_id = 1")) {
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue("Table stats should exist", rs.next());
+                    assertEquals(3, rs.getLong("record_count"));
+                    assertEquals(3, rs.getLong("next_row_id"));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSnapshotCreated() throws Exception {
+        StructType writeSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        spark.createDataFrame(
+                Arrays.asList(RowFactory.create(1, "test", 1.0)),
+                writeSchema
+        ).write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_table")
+                .mode(SaveMode.Append).save();
+
+        // Verify new snapshot was created
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catalogPath)) {
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT MAX(snapshot_id) FROM ducklake_snapshot")) {
+                assertTrue(rs.next());
+                assertTrue("New snapshot should be > 1", rs.getLong(1) >= 2);
+            }
+
+            // Verify snapshot changes recorded
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery(
+                     "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = " +
+                     "(SELECT MAX(snapshot_id) FROM ducklake_snapshot)")) {
+                assertTrue(rs.next());
+                String changes = rs.getString("changes_made");
+                assertTrue("Changes should reference the table",
+                        changes.contains("inserted_into_table"));
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Catalog setup helper
+    // ---------------------------------------------------------------
+
+    private void createCatalog(String catPath, String dp, String tableName, String tablePath,
+                               String[] colNames, String[] colTypes, long[] colIds) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catPath)) {
+            conn.setAutoCommit(false);
+
+            try (Statement st = conn.createStatement()) {
+                // Core metadata tables
+                st.execute("CREATE TABLE ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY, snapshot_time TEXT, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot_changes(snapshot_id BIGINT PRIMARY KEY, changes_made VARCHAR, author VARCHAR, commit_message VARCHAR, commit_extra_info VARCHAR)");
+                st.execute("CREATE TABLE ducklake_schema(schema_id BIGINT PRIMARY KEY, schema_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_table(table_id BIGINT, table_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_id BIGINT, table_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_column(column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR, column_type VARCHAR, initial_default VARCHAR, default_value VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR)");
+                st.execute("CREATE TABLE ducklake_data_file(data_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, file_order BIGINT, path VARCHAR, path_is_relative BOOLEAN, file_format VARCHAR, record_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, row_id_start BIGINT, partition_id BIGINT, encryption_key VARCHAR, mapping_id BIGINT, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_column_stats(data_file_id BIGINT, table_id BIGINT, column_id BIGINT, column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN, extra_stats VARCHAR)");
+                st.execute("CREATE TABLE ducklake_table_stats(table_id BIGINT, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT)");
+                st.execute("CREATE TABLE ducklake_delete_file(delete_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, format VARCHAR, delete_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, encryption_key VARCHAR, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)");
+
+                // Insert metadata
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('version', '0.4')");
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('data_path', '" + dp + "')");
+
+                // Snapshot 0: create schema
+                st.execute("INSERT INTO ducklake_snapshot VALUES (0, datetime('now'), 0, 1, 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (0, 'created_schema:\"main\"', NULL, NULL, NULL)");
+
+                // Schema
+                st.execute("INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', 'main/', 1)");
+
+                // Snapshot 1: create table
+                long tableId = 1;
+                long nextCatalogId = 2;
+                st.execute("INSERT INTO ducklake_snapshot VALUES (1, datetime('now'), 1, " + nextCatalogId + ", 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (1, 'created_table:\"main\".\"" + tableName + "\"', NULL, NULL, NULL)");
+
+                // Table
+                st.execute("INSERT INTO ducklake_table VALUES (" + tableId + ", 'table-uuid-" + tableName + "', 1, NULL, 0, '" + tableName + "', '" + tablePath + "', 1)");
+
+                // Columns
+                for (int i = 0; i < colNames.length; i++) {
+                    st.execute("INSERT INTO ducklake_column VALUES (" + colIds[i] + ", 1, NULL, " + tableId + ", " + i + ", '" + colNames[i] + "', '" + colTypes[i] + "', NULL, NULL, 1, NULL, NULL, NULL)");
+                }
+
+                // Initialize table stats
+                st.execute("INSERT INTO ducklake_table_stats VALUES (" + tableId + ", 0, 0, 0)");
+            }
+
+            conn.commit();
+        }
+    }
+
+    private void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
## Summary

Implements basic write support for the DuckLake Spark connector, enabling `df.write` operations against DuckLake catalogs. This is the most critical missing piece — the connector was previously read-only.

### Usage

```java
// Append
df.write().format("io.ducklake.spark.DuckLakeDataSource")
    .option("catalog", "/path/to/catalog.ducklake")
    .option("table", "my_table")
    .mode(SaveMode.Append)
    .save();

// Overwrite
df.write().format("io.ducklake.spark.DuckLakeDataSource")
    .option("catalog", "/path/to/catalog.ducklake")
    .option("table", "my_table")
    .mode(SaveMode.Overwrite)
    .save();
```

### Architecture

**Writer pipeline (Spark DataSource V2):**
1. `DuckLakeTable.newWriteBuilder()` → `DuckLakeWriteBuilder` (supports truncate for overwrite)
2. `DuckLakeWriteBuilder.build()` → `DuckLakeBatchWrite` (manages batch lifecycle)
3. `DuckLakeBatchWrite.createBatchWriterFactory()` → `DuckLakeDataWriterFactory` (serialized to executors)
4. Each partition gets a `DuckLakeDataWriter` that:
   - Writes `InternalRow` data to Parquet files with DuckLake `field_id` metadata
   - Collects per-column statistics (min, max, null_count, value_count)
5. `DuckLakeBatchWrite.commit()`: Creates snapshot, registers data files + stats in catalog

**Catalog operations added to `DuckLakeMetadataBackend`:**
- Transaction management (begin/commit/rollback)
- Snapshot creation with change tracking
- Data file registration with row_id sequencing
- Column statistics insertion
- Table stats upsert
- Mark files deleted (for overwrite)

### Supported Types
boolean, byte, short, int, long, float, double, string, binary, date, timestamp, decimal

### Write Modes
- **append**: Add new data files alongside existing ones
- **overwrite**: Mark all existing files as deleted, add new data files

### Tests (7 new)
- Basic append write + read back verification
- Multiple sequential appends
- Overwrite mode (replaces data correctly)
- Type round-trip (8 primitive types written and read back)
- Null value handling
- Column statistics recorded correctly in catalog
- Snapshot creation and change tracking

All 20 tests pass (13 existing + 7 new).

Refs #1