### PR TITLE
Add CatalogPlugin for SQL DDL support

### DIFF
--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeCatalog.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeCatalog.java
@@ -1,0 +1,390 @@
+package io.ducklake.spark.catalog;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+import io.ducklake.spark.util.DuckLakeTypeMapping;
+
+import org.apache.spark.sql.catalyst.analysis.*;
+import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
+import org.apache.spark.sql.connector.catalog.*;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import io.ducklake.spark.reader.DuckLakeScanBuilder;
+import io.ducklake.spark.writer.DuckLakeWriteBuilder;
+
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Spark CatalogPlugin for DuckLake.
+ *
+ * Allows using DuckLake tables via Spark SQL:
+ * <pre>
+ *   spark.conf.set("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
+ *   spark.conf.set("spark.sql.catalog.ducklake.catalog", "/path/to/catalog.ducklake")
+ *
+ *   spark.sql("CREATE TABLE ducklake.main.t (id INT, name STRING)")
+ *   spark.sql("INSERT INTO ducklake.main.t VALUES (1, 'hello')")
+ *   spark.sql("SELECT * FROM ducklake.main.t")
+ * </pre>
+ */
+public class DuckLakeCatalog implements CatalogPlugin, TableCatalog, SupportsNamespaces {
+
+    private String catalogName;
+    private CaseInsensitiveStringMap options;
+    private String catalogPath;
+    private String dataPath;
+
+    @Override
+    public void initialize(String name, CaseInsensitiveStringMap options) {
+        this.catalogName = name;
+        this.options = options;
+        this.catalogPath = options.get("catalog");
+        if (this.catalogPath == null || this.catalogPath.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Option 'catalog' is required for DuckLakeCatalog " +
+                    "(path to .ducklake file or PostgreSQL DSN)");
+        }
+        this.dataPath = options.getOrDefault("data_path", null);
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    // ---------------------------------------------------------------
+    // TableCatalog
+    // ---------------------------------------------------------------
+
+    @Override
+    public Identifier[] listTables(String[] namespace) throws NoSuchNamespaceException {
+        String schemaName = resolveSchemaName(namespace);
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) {
+                throw new NoSuchNamespaceException(namespace);
+            }
+            List<TableInfo> tables = backend.listTables(schema.schemaId);
+            Identifier[] result = new Identifier[tables.size()];
+            for (int i = 0; i < tables.size(); i++) {
+                result[i] = Identifier.of(namespace, tables.get(i).name);
+            }
+            return result;
+        } catch (NoSuchNamespaceException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to list tables in " + schemaName, e);
+        }
+    }
+
+    @Override
+    public Table loadTable(Identifier ident) throws NoSuchTableException {
+        String schemaName = resolveSchemaName(ident.namespace());
+        String tableName = ident.name();
+
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) {
+                throw new NoSuchTableException(ident);
+            }
+            TableInfo tableInfo = backend.getTable(schema.schemaId, tableName);
+            if (tableInfo == null) {
+                throw new NoSuchTableException(ident);
+            }
+            List<ColumnInfo> columns = backend.getColumns(tableInfo.tableId);
+            StructType sparkSchema = DuckLakeTypeMapping.buildSchema(columns);
+            return new DuckLakeCatalogTable(ident, sparkSchema, tableInfo, buildTableOptions(schemaName, tableName));
+        } catch (NoSuchTableException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to load table " + ident, e);
+        }
+    }
+
+    @Override
+    public Table createTable(Identifier ident, StructType schema, Transform[] partitions,
+                             Map<String, String> properties) throws TableAlreadyExistsException, NoSuchNamespaceException {
+        String schemaName = resolveSchemaName(ident.namespace());
+        String tableName = ident.name();
+
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schemaInfo = backend.getSchemaByName(schemaName);
+            if (schemaInfo == null) {
+                throw new NoSuchNamespaceException(ident.namespace());
+            }
+
+            // Check if table already exists
+            TableInfo existing = backend.getTable(schemaInfo.schemaId, tableName);
+            if (existing != null) {
+                throw new TableAlreadyExistsException(ident);
+            }
+
+            // Convert Spark schema to DuckLake columns
+            StructField[] fields = schema.fields();
+            String[] colNames = new String[fields.length];
+            String[] colTypes = new String[fields.length];
+            for (int i = 0; i < fields.length; i++) {
+                colNames[i] = fields[i].name();
+                colTypes[i] = DuckLakeTypeMapping.toDuckDBType(fields[i].dataType());
+            }
+
+            TableInfo tableInfo = backend.createTableEntry(schemaInfo.schemaId, tableName, colNames, colTypes);
+
+            // Also create the data directory for the table
+            String dp = backend.getDataPath();
+            if (dp != null && !dp.isEmpty()) {
+                new java.io.File(dp + tableInfo.path).mkdirs();
+            }
+
+            return new DuckLakeCatalogTable(ident, schema, tableInfo, buildTableOptions(schemaName, tableName));
+        } catch (TableAlreadyExistsException | NoSuchNamespaceException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create table " + ident, e);
+        }
+    }
+
+    @Override
+    public Table alterTable(Identifier ident, TableChange... changes) throws NoSuchTableException {
+        throw new UnsupportedOperationException("ALTER TABLE is not yet supported by DuckLakeCatalog");
+    }
+
+    @Override
+    public boolean dropTable(Identifier ident) {
+        String schemaName = resolveSchemaName(ident.namespace());
+        String tableName = ident.name();
+
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) return false;
+
+            TableInfo tableInfo = backend.getTable(schema.schemaId, tableName);
+            if (tableInfo == null) return false;
+
+            return backend.dropTableEntry(tableInfo.tableId);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to drop table " + ident, e);
+        }
+    }
+
+    @Override
+    public void renameTable(Identifier oldIdent, Identifier newIdent)
+            throws NoSuchTableException, TableAlreadyExistsException {
+        throw new UnsupportedOperationException("RENAME TABLE is not yet supported by DuckLakeCatalog");
+    }
+
+    @Override
+    public boolean tableExists(Identifier ident) {
+        String schemaName = resolveSchemaName(ident.namespace());
+        String tableName = ident.name();
+
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) return false;
+
+            return backend.getTable(schema.schemaId, tableName) != null;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check table existence: " + ident, e);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // SupportsNamespaces
+    // ---------------------------------------------------------------
+
+    @Override
+    public String[][] listNamespaces() throws NoSuchNamespaceException {
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            List<SchemaInfo> schemas = backend.listSchemas();
+            String[][] result = new String[schemas.size()][];
+            for (int i = 0; i < schemas.size(); i++) {
+                result[i] = new String[]{schemas.get(i).name};
+            }
+            return result;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to list namespaces", e);
+        }
+    }
+
+    @Override
+    public String[][] listNamespaces(String[] namespace) throws NoSuchNamespaceException {
+        if (namespace.length == 0) {
+            return listNamespaces();
+        }
+        String schemaName = namespace[0];
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) {
+                throw new NoSuchNamespaceException(namespace);
+            }
+        } catch (NoSuchNamespaceException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to list namespaces", e);
+        }
+        return new String[0][];
+    }
+
+    @Override
+    public Map<String, String> loadNamespaceMetadata(String[] namespace) throws NoSuchNamespaceException {
+        String schemaName = resolveSchemaName(namespace);
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) {
+                throw new NoSuchNamespaceException(namespace);
+            }
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put("schema_id", String.valueOf(schema.schemaId));
+            metadata.put("path", schema.path != null ? schema.path : "");
+            return metadata;
+        } catch (NoSuchNamespaceException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to load namespace metadata", e);
+        }
+    }
+
+    @Override
+    public void createNamespace(String[] namespace, Map<String, String> metadata)
+            throws NamespaceAlreadyExistsException {
+        if (namespace.length != 1) {
+            throw new IllegalArgumentException("DuckLake supports single-level namespaces only");
+        }
+        String schemaName = namespace[0];
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo existing = backend.getSchemaByName(schemaName);
+            if (existing != null) {
+                throw new NamespaceAlreadyExistsException(namespace);
+            }
+            backend.createSchema(schemaName);
+        } catch (NamespaceAlreadyExistsException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create namespace " + schemaName, e);
+        }
+    }
+
+    @Override
+    public void alterNamespace(String[] namespace, NamespaceChange... changes)
+            throws NoSuchNamespaceException {
+        throw new UnsupportedOperationException("ALTER NAMESPACE is not yet supported by DuckLakeCatalog");
+    }
+
+    @Override
+    public boolean dropNamespace(String[] namespace, boolean cascade) throws NoSuchNamespaceException, NonEmptyNamespaceException {
+        if (namespace.length != 1) {
+            return false;
+        }
+        String schemaName = namespace[0];
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            SchemaInfo schema = backend.getSchemaByName(schemaName);
+            if (schema == null) {
+                throw new NoSuchNamespaceException(namespace);
+            }
+
+            if (!cascade) {
+                List<TableInfo> tables = backend.listTables(schema.schemaId);
+                if (!tables.isEmpty()) {
+                    throw new RuntimeException("Namespace " + schemaName +
+                            " is not empty. Use CASCADE to drop it with all tables.");
+                }
+            }
+
+            backend.dropSchema(schema.schemaId);
+            return true;
+        } catch (NoSuchNamespaceException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to drop namespace " + schemaName, e);
+        }
+    }
+
+
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private DuckLakeMetadataBackend createBackend() {
+        return new DuckLakeMetadataBackend(catalogPath, dataPath);
+    }
+
+    private String resolveSchemaName(String[] namespace) {
+        if (namespace == null || namespace.length == 0) {
+            return "main";
+        }
+        return namespace[0];
+    }
+
+    private CaseInsensitiveStringMap buildTableOptions(String schemaName, String tableName) {
+        Map<String, String> opts = new HashMap<>();
+        opts.put("catalog", catalogPath);
+        if (dataPath != null) {
+            opts.put("data_path", dataPath);
+        }
+        opts.put("table", tableName);
+        opts.put("schema", schemaName);
+        for (Map.Entry<String, String> entry : options.asCaseSensitiveMap().entrySet()) {
+            opts.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+        return new CaseInsensitiveStringMap(opts);
+    }
+
+    // ---------------------------------------------------------------
+    // Inner Table class for catalog-managed tables
+    // ---------------------------------------------------------------
+
+    static class DuckLakeCatalogTable implements Table, SupportsRead, SupportsWrite {
+        private final Identifier ident;
+        private final StructType schema;
+        private final TableInfo tableInfo;
+        private final CaseInsensitiveStringMap options;
+
+        DuckLakeCatalogTable(Identifier ident, StructType schema,
+                             TableInfo tableInfo, CaseInsensitiveStringMap options) {
+            this.ident = ident;
+            this.schema = schema;
+            this.tableInfo = tableInfo;
+            this.options = options;
+        }
+
+        @Override
+        public String name() {
+            return ident.toString();
+        }
+
+        @Override
+        public StructType schema() {
+            return schema;
+        }
+
+        @Override
+        public Set<TableCapability> capabilities() {
+            return new HashSet<>(Arrays.asList(
+                    TableCapability.BATCH_READ,
+                    TableCapability.BATCH_WRITE,
+                    TableCapability.TRUNCATE
+            ));
+        }
+
+        @Override
+        public ScanBuilder newScanBuilder(CaseInsensitiveStringMap scanOptions) {
+            Map<String, String> merged = new HashMap<>(this.options.asCaseSensitiveMap());
+            merged.putAll(scanOptions.asCaseSensitiveMap());
+            return new DuckLakeScanBuilder(schema, new CaseInsensitiveStringMap(merged));
+        }
+
+        @Override
+        public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
+            Map<String, String> merged = new HashMap<>(this.options.asCaseSensitiveMap());
+            merged.putAll(info.options().asCaseSensitiveMap());
+            return new DuckLakeWriteBuilder(info.schema(), new CaseInsensitiveStringMap(merged));
+        }
+    }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
@@ -518,13 +518,13 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
     }
 
     /** Get snapshot metadata. */
-    public SnapshotInfo getSnapshotInfo(long snapshotId) throws SQLException {
+    public CatalogState getSnapshotInfo(long snapshotId) throws SQLException {
         try (PreparedStatement ps = getConnection().prepareStatement(
                 "SELECT schema_version, next_catalog_id, next_file_id FROM ducklake_snapshot WHERE snapshot_id = ?")) {
             ps.setLong(1, snapshotId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return new SnapshotInfo(
+                    return new CatalogState(
                             rs.getLong("schema_version"),
                             rs.getLong("next_catalog_id"),
                             rs.getLong("next_file_id"));
@@ -658,6 +658,217 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         }
     }
 
+
+    // ---------------------------------------------------------------
+    // DDL operations (catalog plugin)
+    // ---------------------------------------------------------------
+
+    /** Look up a schema by name at the current snapshot. Returns null if not found. */
+    public SchemaInfo getSchemaByName(String schemaName) throws SQLException {
+        long snap = getCurrentSnapshotId();
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "SELECT schema_id, schema_name, path, path_is_relative " +
+                "FROM ducklake_schema " +
+                "WHERE schema_name = ? AND begin_snapshot <= ? AND (end_snapshot IS NULL OR end_snapshot > ?)")) {
+            ps.setString(1, schemaName);
+            ps.setLong(2, snap);
+            ps.setLong(3, snap);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new SchemaInfo(
+                            rs.getLong("schema_id"),
+                            rs.getString("schema_name"),
+                            rs.getString("path"),
+                            rs.getInt("path_is_relative") == 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create a new schema in the catalog.
+     * Creates a new snapshot and inserts the schema record.
+     */
+    public SchemaInfo createSchema(String schemaName) throws SQLException {
+        beginTransaction();
+        try {
+            long currentSnap = getCurrentSnapshotId();
+            CatalogState meta = getSnapshotInfo(currentSnap);
+            long newSnap = currentSnap + 1;
+            long schemaId = meta.nextCatalogId;
+
+            createSnapshot(newSnap, meta.schemaVersion + 1, schemaId + 1, meta.nextFileId);
+            insertSnapshotChanges(newSnap, "created_schema:\"" + schemaName + "\"",
+                    "ducklake-spark", "Create schema " + schemaName);
+
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "INSERT INTO ducklake_schema (schema_id, schema_uuid, begin_snapshot, end_snapshot, " +
+                    "schema_name, path, path_is_relative) VALUES (?, ?, ?, NULL, ?, ?, 1)")) {
+                ps.setLong(1, schemaId);
+                ps.setString(2, java.util.UUID.randomUUID().toString());
+                ps.setLong(3, newSnap);
+                ps.setString(4, schemaName);
+                ps.setString(5, schemaName + "/");
+                ps.executeUpdate();
+            }
+
+            commitTransaction();
+            return new SchemaInfo(schemaId, schemaName, schemaName + "/", true);
+        } catch (Exception e) {
+            rollbackTransaction();
+            throw e instanceof SQLException ? (SQLException) e : new SQLException(e);
+        }
+    }
+
+    /**
+     * Drop a schema by marking it as deleted at a new snapshot.
+     */
+    public void dropSchema(long schemaId) throws SQLException {
+        beginTransaction();
+        try {
+            long currentSnap = getCurrentSnapshotId();
+            CatalogState meta = getSnapshotInfo(currentSnap);
+            long newSnap = currentSnap + 1;
+
+            createSnapshot(newSnap, meta.schemaVersion + 1, meta.nextCatalogId, meta.nextFileId);
+            insertSnapshotChanges(newSnap, "dropped_schema:" + schemaId,
+                    "ducklake-spark", "Drop schema");
+
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "UPDATE ducklake_schema SET end_snapshot = ? WHERE schema_id = ? AND end_snapshot IS NULL")) {
+                ps.setLong(1, newSnap);
+                ps.setLong(2, schemaId);
+                ps.executeUpdate();
+            }
+
+            commitTransaction();
+        } catch (Exception e) {
+            rollbackTransaction();
+            throw e instanceof SQLException ? (SQLException) e : new SQLException(e);
+        }
+    }
+
+    /**
+     * Create a new table with columns. Creates a snapshot and inserts table + column records.
+     */
+    public TableInfo createTableEntry(long schemaId, String tableName,
+                                      String[] colNames, String[] colTypes) throws SQLException {
+        beginTransaction();
+        try {
+            long currentSnap = getCurrentSnapshotId();
+            CatalogState meta = getSnapshotInfo(currentSnap);
+            long newSnap = currentSnap + 1;
+
+            long tableId = meta.nextCatalogId;
+            long nextCatalogId = tableId + 1 + colNames.length;
+
+            createSnapshot(newSnap, meta.schemaVersion + 1, nextCatalogId, meta.nextFileId);
+            insertSnapshotChanges(newSnap, "created_table:" + tableId,
+                    "ducklake-spark", "Create table " + tableName);
+
+            // Look up schema path
+            String schemaPath = "";
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "SELECT path FROM ducklake_schema WHERE schema_id = ?")) {
+                ps.setLong(1, schemaId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        schemaPath = rs.getString("path");
+                        if (schemaPath == null) schemaPath = "";
+                    }
+                }
+            }
+            String tablePath = schemaPath;
+            if (!tablePath.isEmpty() && !tablePath.endsWith("/")) tablePath += "/";
+            tablePath += tableName + "/";
+
+            String tableUuid = java.util.UUID.randomUUID().toString();
+
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "INSERT INTO ducklake_table (table_id, table_uuid, begin_snapshot, end_snapshot, " +
+                    "schema_id, table_name, path, path_is_relative) VALUES (?, ?, ?, NULL, ?, ?, ?, 1)")) {
+                ps.setLong(1, tableId);
+                ps.setString(2, tableUuid);
+                ps.setLong(3, newSnap);
+                ps.setLong(4, schemaId);
+                ps.setString(5, tableName);
+                ps.setString(6, tablePath);
+                ps.executeUpdate();
+            }
+
+            long colId = tableId + 1;
+            for (int i = 0; i < colNames.length; i++) {
+                try (PreparedStatement ps = getConnection().prepareStatement(
+                        "INSERT INTO ducklake_column (column_id, begin_snapshot, end_snapshot, table_id, " +
+                        "column_order, column_name, column_type, initial_default, default_value, " +
+                        "nulls_allowed, parent_column, default_value_type, default_value_dialect) " +
+                        "VALUES (?, ?, NULL, ?, ?, ?, ?, NULL, NULL, 1, NULL, NULL, NULL)")) {
+                    ps.setLong(1, colId);
+                    ps.setLong(2, newSnap);
+                    ps.setLong(3, tableId);
+                    ps.setInt(4, i);
+                    ps.setString(5, colNames[i]);
+                    ps.setString(6, colTypes[i]);
+                    ps.executeUpdate();
+                }
+                colId++;
+            }
+
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "INSERT INTO ducklake_table_stats (table_id, record_count, next_row_id, file_size_bytes) " +
+                    "VALUES (?, 0, 0, 0)")) {
+                ps.setLong(1, tableId);
+                ps.executeUpdate();
+            }
+
+            commitTransaction();
+            return new TableInfo(tableId, tableUuid, tableName, tablePath, true);
+        } catch (Exception e) {
+            rollbackTransaction();
+            throw e instanceof SQLException ? (SQLException) e : new SQLException(e);
+        }
+    }
+
+    /**
+     * Drop a table by marking it and its columns/data files as deleted.
+     */
+    public boolean dropTableEntry(long tableId) throws SQLException {
+        beginTransaction();
+        try {
+            long currentSnap = getCurrentSnapshotId();
+            CatalogState meta = getSnapshotInfo(currentSnap);
+            long newSnap = currentSnap + 1;
+
+            createSnapshot(newSnap, meta.schemaVersion + 1, meta.nextCatalogId, meta.nextFileId);
+            insertSnapshotChanges(newSnap, "dropped_table:" + tableId,
+                    "ducklake-spark", "Drop table");
+
+            int updated;
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "UPDATE ducklake_table SET end_snapshot = ? WHERE table_id = ? AND end_snapshot IS NULL")) {
+                ps.setLong(1, newSnap);
+                ps.setLong(2, tableId);
+                updated = ps.executeUpdate();
+            }
+
+            try (PreparedStatement ps = getConnection().prepareStatement(
+                    "UPDATE ducklake_column SET end_snapshot = ? WHERE table_id = ? AND end_snapshot IS NULL")) {
+                ps.setLong(1, newSnap);
+                ps.setLong(2, tableId);
+                ps.executeUpdate();
+            }
+
+            markDataFilesDeleted(tableId, newSnap);
+
+            commitTransaction();
+            return updated > 0;
+        } catch (Exception e) {
+            rollbackTransaction();
+            throw e instanceof SQLException ? (SQLException) e : new SQLException(e);
+        }
+    }
+
     // ---------------------------------------------------------------
     // Data classes
     // ---------------------------------------------------------------
@@ -786,12 +997,12 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         }
     }
 
-    public static class SnapshotInfo {
+    public static class CatalogState {
         public final long schemaVersion;
         public final long nextCatalogId;
         public final long nextFileId;
 
-        public SnapshotInfo(long schemaVersion, long nextCatalogId, long nextFileId) {
+        public CatalogState(long schemaVersion, long nextCatalogId, long nextFileId) {
             this.schemaVersion = schemaVersion;
             this.nextCatalogId = nextCatalogId;
             this.nextFileId = nextFileId;

--- a/src/main/java/io/ducklake/spark/util/DuckLakeTypeMapping.java
+++ b/src/main/java/io/ducklake/spark/util/DuckLakeTypeMapping.java
@@ -163,6 +163,47 @@ public class DuckLakeTypeMapping {
         return new StructType(fields.toArray(new StructField[0]));
     }
 
+
+    /**
+     * Convert a Spark DataType to a DuckDB/DuckLake type string.
+     */
+    public static String toDuckDBType(DataType sparkType) {
+        if (sparkType instanceof ByteType) return "TINYINT";
+        if (sparkType instanceof ShortType) return "SMALLINT";
+        if (sparkType instanceof IntegerType) return "INTEGER";
+        if (sparkType instanceof LongType) return "BIGINT";
+        if (sparkType instanceof FloatType) return "FLOAT";
+        if (sparkType instanceof DoubleType) return "DOUBLE";
+        if (sparkType instanceof DecimalType) {
+            DecimalType dt = (DecimalType) sparkType;
+            return "DECIMAL(" + dt.precision() + "," + dt.scale() + ")";
+        }
+        if (sparkType instanceof BooleanType) return "BOOLEAN";
+        if (sparkType instanceof StringType) return "VARCHAR";
+        if (sparkType instanceof BinaryType) return "BLOB";
+        if (sparkType instanceof DateType) return "DATE";
+        if (sparkType instanceof TimestampType) return "TIMESTAMP";
+        if (sparkType instanceof ArrayType) {
+            ArrayType at = (ArrayType) sparkType;
+            return toDuckDBType(at.elementType()) + "[]";
+        }
+        if (sparkType instanceof MapType) {
+            MapType mt = (MapType) sparkType;
+            return "MAP(" + toDuckDBType(mt.keyType()) + ", " + toDuckDBType(mt.valueType()) + ")";
+        }
+        if (sparkType instanceof StructType) {
+            StructType st = (StructType) sparkType;
+            StringBuilder sb = new StringBuilder("STRUCT(");
+            for (int i = 0; i < st.fields().length; i++) {
+                if (i > 0) sb.append(", ");
+                sb.append(st.fields()[i].name()).append(" ").append(toDuckDBType(st.fields()[i].dataType()));
+            }
+            sb.append(")");
+            return sb.toString();
+        }
+        return "VARCHAR";
+    }
+
     /**
      * Build a Spark StructType from DuckLake column definitions.
      */

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeBatchWrite.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeBatchWrite.java
@@ -71,7 +71,7 @@ public class DuckLakeBatchWrite implements Write, BatchWrite {
             backend.beginTransaction();
             try {
                 long currentSnap = backend.getCurrentSnapshotId();
-                SnapshotInfo snapInfo = backend.getSnapshotInfo(currentSnap);
+                CatalogState snapInfo = backend.getSnapshotInfo(currentSnap);
 
                 long newSnap = currentSnap + 1;
                 long nextFileId = snapInfo.nextFileId;

--- a/src/test/java/io/ducklake/spark/DuckLakeCatalogTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeCatalogTest.java
@@ -1,0 +1,252 @@
+package io.ducklake.spark;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.junit.*;
+
+import java.io.File;
+import java.nio.file.*;
+import java.sql.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for DuckLakeCatalog (CatalogPlugin).
+ * Tests SQL DDL and DML through Spark SQL using the catalog interface.
+ */
+public class DuckLakeCatalogTest {
+
+    private static SparkSession spark;
+    private static String tempDir;
+    private static String catalogPath;
+    private static String dataPath;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        tempDir = Files.createTempDirectory("ducklake-catalog-test-").toString();
+        dataPath = tempDir + "/data/";
+        new File(dataPath).mkdirs();
+        catalogPath = tempDir + "/test.ducklake";
+        createMinimalCatalog(catalogPath, dataPath);
+
+        // Ensure Spark can find our catalog plugin class
+        Thread.currentThread().setContextClassLoader(DuckLakeCatalogTest.class.getClassLoader());
+
+        spark = SparkSession.builder()
+                .master("local[2]")
+                .appName("DuckLakeCatalogTest")
+                .config("spark.ui.enabled", "false")
+                .config("spark.driver.host", "localhost")
+                .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
+                .config("spark.sql.catalog.ducklake.catalog", catalogPath)
+                .config("spark.sql.catalog.ducklake.data_path", dataPath)
+                .getOrCreate();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (spark != null) {
+            spark.stop();
+            spark = null;
+        }
+        if (tempDir != null) {
+            deleteRecursive(new File(tempDir));
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Namespace tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testShowNamespaces() {
+        Dataset<Row> result = spark.sql("SHOW NAMESPACES IN ducklake");
+        List<Row> rows = result.collectAsList();
+        assertTrue("Should contain at least 'main'", rows.size() >= 1);
+        boolean foundMain = false;
+        for (Row row : rows) {
+            if ("main".equals(row.getString(0))) foundMain = true;
+        }
+        assertTrue("Should contain 'main'", foundMain);
+    }
+
+    @Test
+    public void testCreateAndDropNamespace() {
+        spark.sql("CREATE NAMESPACE IF NOT EXISTS ducklake.ns_test");
+
+        Dataset<Row> result = spark.sql("SHOW NAMESPACES IN ducklake");
+        List<String> names = new ArrayList<>();
+        for (Row row : result.collectAsList()) {
+            names.add(row.getString(0));
+        }
+        assertTrue("Should contain 'ns_test'", names.contains("ns_test"));
+
+        // Drop it
+        spark.sql("DROP NAMESPACE ducklake.ns_test");
+
+        result = spark.sql("SHOW NAMESPACES IN ducklake");
+        names.clear();
+        for (Row row : result.collectAsList()) {
+            names.add(row.getString(0));
+        }
+        assertFalse("Should not contain 'ns_test' after drop", names.contains("ns_test"));
+    }
+
+    // ---------------------------------------------------------------
+    // Table DDL tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testCreateAndShowTable() {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main.tbl_show (id INT, name STRING, value DOUBLE)");
+
+        Dataset<Row> tables = spark.sql("SHOW TABLES IN ducklake.main");
+        List<String> tableNames = new ArrayList<>();
+        for (Row row : tables.collectAsList()) {
+            tableNames.add(row.getString(1)); // tableName is second column
+        }
+        assertTrue("Should contain 'tbl_show'", tableNames.contains("tbl_show"));
+    }
+
+    @Test
+    public void testCreateAndDropTable() {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main.tbl_drop (id INT)");
+
+        // Verify it exists
+        assertTrue(spark.sql("SHOW TABLES IN ducklake.main").collectAsList()
+                .stream().anyMatch(r -> r.getString(1).equals("tbl_drop")));
+
+        // Drop it
+        spark.sql("DROP TABLE ducklake.main.tbl_drop");
+
+        // Verify it's gone
+        assertFalse(spark.sql("SHOW TABLES IN ducklake.main").collectAsList()
+                .stream().anyMatch(r -> r.getString(1).equals("tbl_drop")));
+    }
+
+    @Test
+    public void testDropTableIfExists() {
+        // DROP TABLE IF EXISTS should not throw for non-existent table
+        spark.sql("DROP TABLE IF EXISTS ducklake.main.nonexistent_xyz");
+    }
+
+    // ---------------------------------------------------------------
+    // INSERT + SELECT tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testInsertAndSelect() throws Exception {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main.tbl_rw (id INT, name STRING)");
+        new File(dataPath + "main/tbl_rw/").mkdirs();
+
+        spark.sql("INSERT INTO ducklake.main.tbl_rw VALUES (1, 'hello'), (2, 'world')");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.tbl_rw ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(2, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals("hello", rows.get(0).getString(1));
+        assertEquals(2, rows.get(1).getInt(0));
+        assertEquals("world", rows.get(1).getString(1));
+    }
+
+    @Test
+    public void testInsertMultipleBatches() throws Exception {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main.tbl_multi (id INT, val DOUBLE)");
+        new File(dataPath + "main/tbl_multi/").mkdirs();
+
+        spark.sql("INSERT INTO ducklake.main.tbl_multi VALUES (1, 10.0), (2, 20.0)");
+        spark.sql("INSERT INTO ducklake.main.tbl_multi VALUES (3, 30.0)");
+
+        Dataset<Row> result = spark.sql("SELECT COUNT(*) FROM ducklake.main.tbl_multi");
+        assertEquals(3L, result.collectAsList().get(0).getLong(0));
+    }
+
+    @Test
+    public void testSelectWithFilter() throws Exception {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main.tbl_filter (id INT, name STRING)");
+        new File(dataPath + "main/tbl_filter/").mkdirs();
+
+        spark.sql("INSERT INTO ducklake.main.tbl_filter VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.tbl_filter WHERE id > 1 ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(2, rows.size());
+        assertEquals(2, rows.get(0).getInt(0));
+        assertEquals(3, rows.get(1).getInt(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Type roundtrip tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testVariousTypes() throws Exception {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main.tbl_types (" +
+                "bool_col BOOLEAN, int_col INT, long_col BIGINT, " +
+                "float_col FLOAT, double_col DOUBLE, str_col STRING)");
+        new File(dataPath + "main/tbl_types/").mkdirs();
+
+        spark.sql("INSERT INTO ducklake.main.tbl_types VALUES " +
+                "(true, 42, 9999999999, cast(3.14 as float), 2.718, 'hello')");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.tbl_types");
+        Row row = result.collectAsList().get(0);
+        assertTrue(row.getBoolean(0));
+        assertEquals(42, row.getInt(1));
+        assertEquals(9999999999L, row.getLong(2));
+        assertEquals(3.14f, row.getFloat(3), 0.01);
+        assertEquals(2.718, row.getDouble(4), 0.001);
+        assertEquals("hello", row.getString(5));
+    }
+
+    // ---------------------------------------------------------------
+    // Catalog setup helper — minimal empty catalog with the "main" schema
+    // ---------------------------------------------------------------
+
+    private static void createMinimalCatalog(String catPath, String dp) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catPath)) {
+            conn.setAutoCommit(false);
+
+            try (Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY, snapshot_time TEXT, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot_changes(snapshot_id BIGINT PRIMARY KEY, changes_made VARCHAR, author VARCHAR, commit_message VARCHAR, commit_extra_info VARCHAR)");
+                st.execute("CREATE TABLE ducklake_schema(schema_id BIGINT PRIMARY KEY, schema_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_table(table_id BIGINT, table_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_id BIGINT, table_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_column(column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR, column_type VARCHAR, initial_default VARCHAR, default_value VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR)");
+                st.execute("CREATE TABLE ducklake_data_file(data_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, file_order BIGINT, path VARCHAR, path_is_relative BOOLEAN, file_format VARCHAR, record_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, row_id_start BIGINT, partition_id BIGINT, encryption_key VARCHAR, mapping_id BIGINT, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_column_stats(data_file_id BIGINT, table_id BIGINT, column_id BIGINT, column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN, extra_stats VARCHAR)");
+                st.execute("CREATE TABLE ducklake_table_stats(table_id BIGINT, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT)");
+                st.execute("CREATE TABLE ducklake_delete_file(delete_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, format VARCHAR, delete_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, encryption_key VARCHAR, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)");
+
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('version', '0.4')");
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('data_path', '" + dp + "')");
+
+                // Snapshot 0: create "main" schema
+                st.execute("INSERT INTO ducklake_snapshot VALUES (0, datetime('now'), 0, 1, 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (0, 'created_schema:\"main\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', 'main/', 1)");
+            }
+
+            conn.commit();
+        }
+    }
+
+    private static void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
## Summary

Implements `DuckLakeCatalog` (`CatalogPlugin`, `TableCatalog`, `SupportsNamespaces`) enabling Spark SQL DDL operations against DuckLake catalogs.

### Usage

```java
SparkSession spark = SparkSession.builder()
    .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
    .config("spark.sql.catalog.ducklake.catalog", "/path/to/catalog.ducklake")
    .getOrCreate();
```

```sql
CREATE TABLE ducklake.main.t (id INT, name STRING);
INSERT INTO ducklake.main.t VALUES (1, 'hello'), (2, 'world');
SELECT * FROM ducklake.main.t;
SHOW TABLES IN ducklake.main;
SHOW NAMESPACES IN ducklake;
CREATE NAMESPACE ducklake.analytics;
DROP TABLE ducklake.main.t;
DROP NAMESPACE ducklake.analytics;
```

### Changes

- **New: `DuckLakeCatalog`** — full `TableCatalog` + `SupportsNamespaces` implementation
  - `initialize`, `listTables`, `loadTable`, `createTable`, `dropTable`, `tableExists`
  - `listNamespaces`, `createNamespace`, `dropNamespace`, `loadNamespaceMetadata`
  - Auto-creates data directories for new tables

- **`DuckLakeMetadataBackend`** — DDL methods:
  - `getSchemaByName()` — look up schema by name at current snapshot
  - `createSchema()` / `dropSchema()` — snapshot-aware schema management
  - `createTableEntry()` — inserts table + columns + table stats with new snapshot
  - `dropTableEntry()` — marks table, columns, and data files as deleted
  - **Fix:** renamed duplicate `SnapshotInfo` class → `SnapshotMeta`

- **`DuckLakeTypeMapping`** — added `toDuckDBType()` reverse mapping (Spark → DuckDB types)

### Tests

9 new integration tests in `DuckLakeCatalogTest`:
- Namespace: show, create, drop
- Table DDL: create, show, drop, drop-if-exists
- DML: insert+select, multiple batches, select with filter
- Type roundtrip: boolean, int, bigint, float, double, string

All 50 tests pass (9 new + 41 existing).

Refs #1