### PR TITLE
feat: row-level DELETE and UPDATE operations

### DIFF
--- a/src/main/java/io/ducklake/spark/DuckLakeDataSource.java
+++ b/src/main/java/io/ducklake/spark/DuckLakeDataSource.java
@@ -1,6 +1,7 @@
 package io.ducklake.spark;
 
 import io.ducklake.spark.reader.DuckLakeScanBuilder;
+import io.ducklake.spark.writer.DuckLakeDeleteExecutor;
 import io.ducklake.spark.writer.DuckLakeWriteBuilder;
 import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
 import io.ducklake.spark.util.DuckLakeTypeMapping;
@@ -8,6 +9,7 @@ import io.ducklake.spark.util.DuckLakeTypeMapping;
 import org.apache.spark.sql.connector.catalog.*;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.types.StructType;
@@ -87,7 +89,7 @@ public class DuckLakeDataSource implements TableProvider {
     // Inner Table class implementing SupportsRead
     // ---------------------------------------------------------------
 
-    static class DuckLakeTable implements Table, SupportsRead, SupportsWrite {
+    static class DuckLakeTable implements Table, SupportsRead, SupportsWrite, SupportsDelete {
         private final StructType schema;
         private final CaseInsensitiveStringMap options;
 
@@ -128,6 +130,21 @@ public class DuckLakeDataSource implements TableProvider {
             Map<String, String> merged = new HashMap<>(this.options.asCaseSensitiveMap());
             merged.putAll(info.options().asCaseSensitiveMap());
             return new DuckLakeWriteBuilder(info.schema(), new CaseInsensitiveStringMap(merged));
+        }
+
+        @Override
+        public boolean canDeleteWhere(Filter[] filters) {
+            return true;
+        }
+
+        @Override
+        public void deleteWhere(Filter[] filters) {
+            new DuckLakeDeleteExecutor(
+                    options.get("catalog"),
+                    options.getOrDefault("data_path", null),
+                    options.get("table"),
+                    options.getOrDefault("schema", "main")
+            ).deleteWhere(filters);
         }
     }
 }

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeCatalog.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeCatalog.java
@@ -8,6 +8,7 @@ import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
 import org.apache.spark.sql.connector.catalog.*;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.types.StructField;
@@ -15,6 +16,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 import io.ducklake.spark.reader.DuckLakeScanBuilder;
+import io.ducklake.spark.writer.DuckLakeDeleteExecutor;
 import io.ducklake.spark.writer.DuckLakeWriteBuilder;
 
 import java.sql.SQLException;
@@ -340,7 +342,7 @@ public class DuckLakeCatalog implements CatalogPlugin, TableCatalog, SupportsNam
     // Inner Table class for catalog-managed tables
     // ---------------------------------------------------------------
 
-    static class DuckLakeCatalogTable implements Table, SupportsRead, SupportsWrite {
+    static class DuckLakeCatalogTable implements Table, SupportsRead, SupportsWrite, SupportsDelete {
         private final Identifier ident;
         private final StructType schema;
         private final TableInfo tableInfo;
@@ -385,6 +387,21 @@ public class DuckLakeCatalog implements CatalogPlugin, TableCatalog, SupportsNam
             Map<String, String> merged = new HashMap<>(this.options.asCaseSensitiveMap());
             merged.putAll(info.options().asCaseSensitiveMap());
             return new DuckLakeWriteBuilder(info.schema(), new CaseInsensitiveStringMap(merged));
+        }
+
+        @Override
+        public boolean canDeleteWhere(Filter[] filters) {
+            return true;
+        }
+
+        @Override
+        public void deleteWhere(Filter[] filters) {
+            new DuckLakeDeleteExecutor(
+                    options.get("catalog"),
+                    options.getOrDefault("data_path", null),
+                    options.get("table"),
+                    options.getOrDefault("schema", "main")
+            ).deleteWhere(filters);
         }
     }
 }

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
@@ -658,6 +658,36 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         }
     }
 
+    /** Insert a delete file record. */
+    public void insertDeleteFile(long deleteFileId, long tableId, long beginSnapshot,
+                                  long dataFileId, String path, long deleteCount,
+                                  long fileSizeBytes) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "INSERT INTO ducklake_delete_file (delete_file_id, table_id, begin_snapshot, end_snapshot, " +
+                "data_file_id, path, path_is_relative, format, delete_count, file_size_bytes, " +
+                "footer_size, encryption_key, partial_max) " +
+                "VALUES (?, ?, ?, NULL, ?, ?, 1, 'PARQUET', ?, ?, 0, NULL, NULL)")) {
+            ps.setLong(1, deleteFileId);
+            ps.setLong(2, tableId);
+            ps.setLong(3, beginSnapshot);
+            ps.setLong(4, dataFileId);
+            ps.setString(5, path);
+            ps.setLong(6, deleteCount);
+            ps.setLong(7, fileSizeBytes);
+            ps.executeUpdate();
+        }
+    }
+
+    /** Mark all active delete files for a table as deleted at the given snapshot. */
+    public void markDeleteFilesDeleted(long tableId, long snapshotId) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "UPDATE ducklake_delete_file SET end_snapshot = ? WHERE table_id = ? AND end_snapshot IS NULL")) {
+            ps.setLong(1, snapshotId);
+            ps.setLong(2, tableId);
+            ps.executeUpdate();
+        }
+    }
+
 
     // ---------------------------------------------------------------
     // DDL operations (catalog plugin)
@@ -860,6 +890,7 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
             }
 
             markDataFilesDeleted(tableId, newSnap);
+            markDeleteFilesDeleted(tableId, newSnap);
 
             commitTransaction();
             return updated > 0;

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeDeleteExecutor.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeDeleteExecutor.java
@@ -1,0 +1,304 @@
+package io.ducklake.spark.writer;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+import io.ducklake.spark.util.DuckLakeTypeMapping;
+
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.RecordReader;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.schema.*;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Executes row-level DELETE operations on DuckLake tables.
+ *
+ * Scans all data files, evaluates the WHERE predicate against each row,
+ * and writes delete files for matching rows. Delete files are Parquet files
+ * with a single {@code row_id} column indicating which row positions to exclude.
+ */
+public class DuckLakeDeleteExecutor {
+
+    private final String catalogPath;
+    private final String dataPathOption;
+    private final String tableName;
+    private final String schemaName;
+
+    public DuckLakeDeleteExecutor(String catalogPath, String dataPathOption,
+                                   String tableName, String schemaName) {
+        this.catalogPath = catalogPath;
+        this.dataPathOption = dataPathOption;
+        this.tableName = tableName;
+        this.schemaName = schemaName;
+    }
+
+    /**
+     * Delete all rows matching the given filters.
+     * Creates delete files and registers them in the catalog.
+     */
+    public void deleteWhere(Filter[] filters) {
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            backend.beginTransaction();
+            try {
+                long currentSnap = backend.getCurrentSnapshotId();
+
+                TableInfo table = backend.getTable(tableName, schemaName, currentSnap);
+                if (table == null) {
+                    throw new RuntimeException("Table not found: " + schemaName + "." + tableName);
+                }
+
+                String dataPath = backend.getDataPath();
+                if (!dataPath.endsWith("/")) dataPath += "/";
+
+                List<DataFileInfo> dataFiles = backend.getDataFiles(table.tableId, currentSnap);
+                List<ColumnInfo> columns = backend.getColumns(table.tableId, currentSnap);
+
+                StructType sparkSchema = DuckLakeTypeMapping.buildSchema(columns);
+
+                Map<Long, String> colIdToName = new HashMap<>();
+                for (ColumnInfo col : columns) {
+                    colIdToName.put(col.columnId, col.name);
+                }
+
+                CatalogState snapInfo = backend.getSnapshotInfo(currentSnap);
+                long nextFileId = snapInfo.nextFileId;
+
+                List<DeleteFileResult> deleteResults = new ArrayList<>();
+
+                for (DataFileInfo dataFile : dataFiles) {
+                    String filePath = dataFile.pathIsRelative ? dataPath + dataFile.path : dataFile.path;
+
+                    // Load existing delete positions for this data file
+                    Set<Long> existingDeletes = loadExistingDeletes(
+                            backend, table.tableId, dataFile.dataFileId, currentSnap, dataPath);
+
+                    // Build logical-to-physical column name mapping
+                    Map<String, String> logicalToPhysical = buildLogicalToPhysical(
+                            backend, dataFile.mappingId, colIdToName);
+
+                    // Scan file and find matching row positions
+                    List<Long> matchingPositions = scanForMatches(
+                            filePath, sparkSchema, filters, existingDeletes, logicalToPhysical);
+
+                    if (!matchingPositions.isEmpty()) {
+                        String deleteFileName = "delete_" + UUID.randomUUID() + ".parquet";
+                        String deleteRelPath = table.path + deleteFileName;
+                        String deleteAbsPath = dataPath + deleteRelPath;
+
+                        writeDeleteFile(deleteAbsPath, matchingPositions);
+
+                        long fileSize = new File(deleteAbsPath).length();
+                        deleteResults.add(new DeleteFileResult(
+                                dataFile.dataFileId, deleteRelPath, matchingPositions.size(), fileSize));
+                    }
+                }
+
+                if (deleteResults.isEmpty()) {
+                    backend.rollbackTransaction();
+                    return;
+                }
+
+                // Create new snapshot
+                long newSnap = currentSnap + 1;
+                long newNextFileId = nextFileId + deleteResults.size();
+                backend.createSnapshot(newSnap, snapInfo.schemaVersion,
+                        snapInfo.nextCatalogId, newNextFileId);
+
+                // Register delete files
+                long deleteFileId = nextFileId;
+                long totalDeleteCount = 0;
+                for (DeleteFileResult result : deleteResults) {
+                    backend.insertDeleteFile(deleteFileId, table.tableId, newSnap,
+                            result.dataFileId, result.relativePath, result.deleteCount, result.fileSize);
+                    totalDeleteCount += result.deleteCount;
+                    deleteFileId++;
+                }
+
+                // Update table stats
+                TableStats stats = backend.getTableStats(table.tableId);
+                backend.updateTableStats(table.tableId,
+                        stats.recordCount - totalDeleteCount, stats.nextRowId, stats.fileSizeBytes);
+
+                // Record changes
+                backend.insertSnapshotChanges(newSnap,
+                        "deleted_from_table:" + table.tableId,
+                        "ducklake-spark", "Spark delete");
+
+                backend.commitTransaction();
+            } catch (Exception e) {
+                try { backend.rollbackTransaction(); } catch (SQLException ex) { e.addSuppressed(ex); }
+                if (e instanceof RuntimeException) throw (RuntimeException) e;
+                throw new RuntimeException("Failed to execute delete", e);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to execute delete", e);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Scanning and matching
+    // ---------------------------------------------------------------
+
+    private List<Long> scanForMatches(String filePath, StructType sparkSchema,
+                                       Filter[] filters, Set<Long> existingDeletes,
+                                       Map<String, String> logicalToPhysical) {
+        List<Long> matchingPositions = new ArrayList<>();
+
+        try (ParquetFileReader reader = ParquetFileReader.open(new Configuration(), new Path(filePath))) {
+            MessageType fileSchema = reader.getFooter().getFileMetaData().getSchema();
+            DuckLakeRowFilterEvaluator evaluator =
+                    new DuckLakeRowFilterEvaluator(sparkSchema, fileSchema, logicalToPhysical);
+
+            long rowPosition = 0;
+            PageReadStore pages;
+            while ((pages = reader.readNextRowGroup()) != null) {
+                long rowCount = pages.getRowCount();
+                ColumnIOFactory factory = new ColumnIOFactory();
+                MessageColumnIO columnIO = factory.getColumnIO(fileSchema);
+                RecordReader<Group> recordReader =
+                        columnIO.getRecordReader(pages, new GroupRecordConverter(fileSchema));
+
+                for (long i = 0; i < rowCount; i++) {
+                    Group group = recordReader.read();
+                    long pos = rowPosition++;
+
+                    // Skip already-deleted rows
+                    if (existingDeletes.contains(pos)) {
+                        continue;
+                    }
+
+                    if (evaluator.matches(group, filters)) {
+                        matchingPositions.add(pos);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to scan file for delete: " + filePath, e);
+        }
+
+        return matchingPositions;
+    }
+
+    // ---------------------------------------------------------------
+    // Delete file writing
+    // ---------------------------------------------------------------
+
+    /**
+     * Write a delete file (Parquet) with a single {@code row_id} column.
+     */
+    static void writeDeleteFile(String absolutePath, List<Long> rowIds) {
+        MessageType deleteSchema = Types.buildMessage()
+                .required(PrimitiveType.PrimitiveTypeName.INT64).named("row_id")
+                .named("delete_file");
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(deleteSchema);
+
+        File parentDir = new File(absolutePath).getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+
+        try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(new Path(absolutePath))
+                .withType(deleteSchema)
+                .withConf(new Configuration())
+                .withWriteMode(ParquetFileWriter.Mode.CREATE)
+                .build()) {
+            for (long rowId : rowIds) {
+                Group group = groupFactory.newGroup();
+                group.add(0, rowId);
+                writer.write(group);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write delete file: " + absolutePath, e);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private Set<Long> loadExistingDeletes(DuckLakeMetadataBackend backend, long tableId,
+                                           long dataFileId, long snapshotId,
+                                           String dataPath) throws SQLException {
+        Set<Long> deleted = new HashSet<>();
+        List<DeleteFileInfo> deleteFiles = backend.getDeleteFiles(tableId, dataFileId, snapshotId);
+
+        for (DeleteFileInfo df : deleteFiles) {
+            String path = df.pathIsRelative ? dataPath + df.path : df.path;
+            try (ParquetFileReader reader = ParquetFileReader.open(new Configuration(), new Path(path))) {
+                MessageType schema = reader.getFooter().getFileMetaData().getSchema();
+                PageReadStore pages;
+                while ((pages = reader.readNextRowGroup()) != null) {
+                    ColumnIOFactory factory = new ColumnIOFactory();
+                    MessageColumnIO columnIO = factory.getColumnIO(schema);
+                    RecordReader<Group> recordReader =
+                            columnIO.getRecordReader(pages, new GroupRecordConverter(schema));
+                    for (long i = 0; i < pages.getRowCount(); i++) {
+                        Group group = recordReader.read();
+                        int fieldIndex = schema.getFieldIndex("row_id");
+                        deleted.add(group.getLong(fieldIndex, 0));
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to read delete file: " + path, e);
+            }
+        }
+
+        return deleted;
+    }
+
+    private Map<String, String> buildLogicalToPhysical(DuckLakeMetadataBackend backend,
+                                                         long mappingId,
+                                                         Map<Long, String> colIdToName) throws SQLException {
+        Map<String, String> logicalToPhysical = new HashMap<>();
+        if (mappingId >= 0) {
+            Map<Long, String> nameMapping = backend.getNameMapping(mappingId);
+            for (Map.Entry<Long, String> entry : nameMapping.entrySet()) {
+                long fieldId = entry.getKey();
+                String physicalName = entry.getValue();
+                String logicalName = colIdToName.get(fieldId);
+                if (logicalName != null && !physicalName.equals(logicalName)) {
+                    logicalToPhysical.put(logicalName, physicalName);
+                }
+            }
+        }
+        return logicalToPhysical;
+    }
+
+    private DuckLakeMetadataBackend createBackend() {
+        return new DuckLakeMetadataBackend(catalogPath, dataPathOption);
+    }
+
+    // ---------------------------------------------------------------
+    // Result data class
+    // ---------------------------------------------------------------
+
+    static class DeleteFileResult {
+        final long dataFileId;
+        final String relativePath;
+        final long deleteCount;
+        final long fileSize;
+
+        DeleteFileResult(long dataFileId, String relativePath, long deleteCount, long fileSize) {
+            this.dataFileId = dataFileId;
+            this.relativePath = relativePath;
+            this.deleteCount = deleteCount;
+            this.fileSize = fileSize;
+        }
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeRowFilterEvaluator.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeRowFilterEvaluator.java
@@ -1,0 +1,249 @@
+package io.ducklake.spark.writer;
+
+import org.apache.spark.sql.sources.*;
+import org.apache.spark.sql.types.*;
+
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.Map;
+
+/**
+ * Evaluates Spark {@link Filter} predicates against individual Parquet rows.
+ * Used by delete/update operations to identify rows matching a WHERE clause.
+ */
+public class DuckLakeRowFilterEvaluator {
+
+    private final StructType sparkSchema;
+    private final MessageType fileSchema;
+    private final Map<String, String> logicalToPhysical;
+
+    public DuckLakeRowFilterEvaluator(StructType sparkSchema, MessageType fileSchema,
+                                       Map<String, String> logicalToPhysical) {
+        this.sparkSchema = sparkSchema;
+        this.fileSchema = fileSchema;
+        this.logicalToPhysical = logicalToPhysical;
+    }
+
+    /**
+     * Returns {@code true} if the given row matches all the provided filters.
+     */
+    public boolean matches(Group group, Filter[] filters) {
+        if (filters == null || filters.length == 0) {
+            return true;
+        }
+        for (Filter filter : filters) {
+            if (!evaluateFilter(group, filter)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean evaluateFilter(Group group, Filter filter) {
+        if (filter instanceof EqualTo) {
+            return evalEqualTo(group, (EqualTo) filter);
+        } else if (filter instanceof EqualNullSafe) {
+            return evalEqualNullSafe(group, (EqualNullSafe) filter);
+        } else if (filter instanceof GreaterThan) {
+            return evalGreaterThan(group, (GreaterThan) filter);
+        } else if (filter instanceof GreaterThanOrEqual) {
+            return evalGreaterThanOrEqual(group, (GreaterThanOrEqual) filter);
+        } else if (filter instanceof LessThan) {
+            return evalLessThan(group, (LessThan) filter);
+        } else if (filter instanceof LessThanOrEqual) {
+            return evalLessThanOrEqual(group, (LessThanOrEqual) filter);
+        } else if (filter instanceof In) {
+            return evalIn(group, (In) filter);
+        } else if (filter instanceof IsNull) {
+            return evalIsNull(group, (IsNull) filter);
+        } else if (filter instanceof IsNotNull) {
+            return evalIsNotNull(group, (IsNotNull) filter);
+        } else if (filter instanceof And) {
+            And and = (And) filter;
+            return evaluateFilter(group, and.left()) && evaluateFilter(group, and.right());
+        } else if (filter instanceof Or) {
+            Or or = (Or) filter;
+            return evaluateFilter(group, or.left()) || evaluateFilter(group, or.right());
+        } else if (filter instanceof Not) {
+            return !evaluateFilter(group, ((Not) filter).child());
+        } else if (filter instanceof StringStartsWith) {
+            return evalStringStartsWith(group, (StringStartsWith) filter);
+        } else if (filter instanceof StringEndsWith) {
+            return evalStringEndsWith(group, (StringEndsWith) filter);
+        } else if (filter instanceof StringContains) {
+            return evalStringContains(group, (StringContains) filter);
+        }
+        return true;
+    }
+
+    // ---------------------------------------------------------------
+    // Individual filter evaluators
+    // ---------------------------------------------------------------
+
+    private boolean evalEqualTo(Group group, EqualTo f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return f.value() == null;
+        if (f.value() == null) return false;
+        return compareValues(rowVal, f.value()) == 0;
+    }
+
+    private boolean evalEqualNullSafe(Group group, EqualNullSafe f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null && f.value() == null) return true;
+        if (rowVal == null || f.value() == null) return false;
+        return compareValues(rowVal, f.value()) == 0;
+    }
+
+    private boolean evalGreaterThan(Group group, GreaterThan f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return compareValues(rowVal, f.value()) > 0;
+    }
+
+    private boolean evalGreaterThanOrEqual(Group group, GreaterThanOrEqual f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return compareValues(rowVal, f.value()) >= 0;
+    }
+
+    private boolean evalLessThan(Group group, LessThan f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return compareValues(rowVal, f.value()) < 0;
+    }
+
+    private boolean evalLessThanOrEqual(Group group, LessThanOrEqual f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return compareValues(rowVal, f.value()) <= 0;
+    }
+
+    private boolean evalIn(Group group, In f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        for (Object val : f.values()) {
+            if (rowVal == null && val == null) return true;
+            if (rowVal != null && val != null && compareValues(rowVal, val) == 0) return true;
+        }
+        return false;
+    }
+
+    private boolean evalIsNull(Group group, IsNull f) {
+        return getColumnValue(group, f.attribute()) == null;
+    }
+
+    private boolean evalIsNotNull(Group group, IsNotNull f) {
+        return getColumnValue(group, f.attribute()) != null;
+    }
+
+    private boolean evalStringStartsWith(Group group, StringStartsWith f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return rowVal.toString().startsWith(f.value().toString());
+    }
+
+    private boolean evalStringEndsWith(Group group, StringEndsWith f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return rowVal.toString().endsWith(f.value().toString());
+    }
+
+    private boolean evalStringContains(Group group, StringContains f) {
+        Object rowVal = getColumnValue(group, f.attribute());
+        if (rowVal == null) return false;
+        return rowVal.toString().contains(f.value().toString());
+    }
+
+    // ---------------------------------------------------------------
+    // Value extraction and comparison
+    // ---------------------------------------------------------------
+
+    private Object getColumnValue(Group group, String logicalName) {
+        String physicalName = logicalToPhysical.getOrDefault(logicalName, logicalName);
+
+        int fieldIndex;
+        try {
+            fieldIndex = fileSchema.getFieldIndex(physicalName);
+        } catch (Exception e) {
+            return null;
+        }
+
+        if (group.getFieldRepetitionCount(fieldIndex) == 0) {
+            return null;
+        }
+
+        DataType sparkType = null;
+        for (StructField field : sparkSchema.fields()) {
+            if (field.name().equalsIgnoreCase(logicalName)) {
+                sparkType = field.dataType();
+                break;
+            }
+        }
+        if (sparkType == null) {
+            return group.getValueToString(fieldIndex, 0);
+        }
+
+        return readTypedValue(group, fieldIndex, sparkType);
+    }
+
+    private Object readTypedValue(Group group, int fieldIndex, DataType sparkType) {
+        try {
+            if (sparkType instanceof BooleanType) {
+                return group.getBoolean(fieldIndex, 0);
+            } else if (sparkType instanceof ByteType) {
+                return (int) group.getInteger(fieldIndex, 0);
+            } else if (sparkType instanceof ShortType) {
+                return (int) group.getInteger(fieldIndex, 0);
+            } else if (sparkType instanceof IntegerType) {
+                return group.getInteger(fieldIndex, 0);
+            } else if (sparkType instanceof LongType) {
+                return group.getLong(fieldIndex, 0);
+            } else if (sparkType instanceof FloatType) {
+                return (double) group.getFloat(fieldIndex, 0);
+            } else if (sparkType instanceof DoubleType) {
+                return group.getDouble(fieldIndex, 0);
+            } else if (sparkType instanceof StringType) {
+                return group.getString(fieldIndex, 0);
+            } else {
+                return group.getValueToString(fieldIndex, 0);
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static int compareValues(Object rowValue, Object filterValue) {
+        if (rowValue == null && filterValue == null) return 0;
+        if (rowValue == null) return -1;
+        if (filterValue == null) return 1;
+
+        if (isNumeric(rowValue) && isNumeric(filterValue)) {
+            double rv = ((Number) rowValue).doubleValue();
+            double fv = ((Number) filterValue).doubleValue();
+            return Double.compare(rv, fv);
+        }
+
+        if (rowValue instanceof String || filterValue instanceof String) {
+            return rowValue.toString().compareTo(filterValue.toString());
+        }
+
+        if (rowValue instanceof Boolean && filterValue instanceof Boolean) {
+            return Boolean.compare((Boolean) rowValue, (Boolean) filterValue);
+        }
+
+        if (rowValue instanceof Comparable && filterValue instanceof Comparable) {
+            try {
+                return ((Comparable) rowValue).compareTo(filterValue);
+            } catch (ClassCastException e) {
+                return rowValue.toString().compareTo(filterValue.toString());
+            }
+        }
+
+        return rowValue.toString().compareTo(filterValue.toString());
+    }
+
+    private static boolean isNumeric(Object value) {
+        return value instanceof Number;
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeUpdateExecutor.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeUpdateExecutor.java
@@ -1,0 +1,523 @@
+package io.ducklake.spark.writer;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+import io.ducklake.spark.util.DuckLakeTypeMapping;
+
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.*;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.RecordReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.schema.*;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Executes row-level UPDATE operations on DuckLake tables.
+ *
+ * For each matching row:
+ *   1. Records its position in a delete file (marks old version as deleted)
+ *   2. Writes updated row to a new data file (inserts new version)
+ *
+ * This is the standard copy-on-write approach for DuckLake updates.
+ */
+public class DuckLakeUpdateExecutor {
+
+    private final String catalogPath;
+    private final String dataPathOption;
+    private final String tableName;
+    private final String schemaName;
+
+    public DuckLakeUpdateExecutor(String catalogPath, String dataPathOption,
+                                   String tableName, String schemaName) {
+        this.catalogPath = catalogPath;
+        this.dataPathOption = dataPathOption;
+        this.tableName = tableName;
+        this.schemaName = schemaName;
+    }
+
+    /**
+     * Update rows matching the filters, setting column values from the updates map.
+     *
+     * @param filters WHERE clause predicates
+     * @param updates Map from column name to new value (Java objects matching Spark types)
+     */
+    public void updateWhere(Filter[] filters, Map<String, Object> updates) {
+        try (DuckLakeMetadataBackend backend = createBackend()) {
+            backend.beginTransaction();
+            try {
+                long currentSnap = backend.getCurrentSnapshotId();
+
+                TableInfo table = backend.getTable(tableName, schemaName, currentSnap);
+                if (table == null) {
+                    throw new RuntimeException("Table not found: " + schemaName + "." + tableName);
+                }
+
+                String dataPath = backend.getDataPath();
+                if (!dataPath.endsWith("/")) dataPath += "/";
+
+                List<DataFileInfo> dataFiles = backend.getDataFiles(table.tableId, currentSnap);
+                List<ColumnInfo> columns = backend.getColumns(table.tableId, currentSnap);
+
+                StructType sparkSchema = DuckLakeTypeMapping.buildSchema(columns);
+
+                Map<Long, String> colIdToName = new HashMap<>();
+                for (ColumnInfo col : columns) {
+                    colIdToName.put(col.columnId, col.name);
+                }
+
+                // Map column name -> column id
+                Map<String, Long> nameToColId = new HashMap<>();
+                for (ColumnInfo col : columns) {
+                    nameToColId.put(col.name, col.columnId);
+                }
+
+                long[] columnIds = new long[columns.size()];
+                for (int i = 0; i < columns.size(); i++) {
+                    columnIds[i] = columns.get(i).columnId;
+                }
+
+                CatalogState snapInfo = backend.getSnapshotInfo(currentSnap);
+                long nextFileId = snapInfo.nextFileId;
+
+                List<DuckLakeDeleteExecutor.DeleteFileResult> deleteResults = new ArrayList<>();
+                List<UpdateDataFileResult> newDataFiles = new ArrayList<>();
+
+                for (DataFileInfo dataFile : dataFiles) {
+                    String filePath = dataFile.pathIsRelative ? dataPath + dataFile.path : dataFile.path;
+
+                    Set<Long> existingDeletes = loadExistingDeletes(
+                            backend, table.tableId, dataFile.dataFileId, currentSnap, dataPath);
+
+                    Map<String, String> logicalToPhysical = buildLogicalToPhysical(
+                            backend, dataFile.mappingId, colIdToName);
+
+                    // Scan file: collect delete positions and updated rows
+                    ScanResult scanResult = scanAndCollectUpdates(
+                            filePath, sparkSchema, filters, existingDeletes,
+                            logicalToPhysical, updates, columnIds);
+
+                    if (!scanResult.deletePositions.isEmpty()) {
+                        // Write delete file
+                        String deleteFileName = "delete_" + UUID.randomUUID() + ".parquet";
+                        String deleteRelPath = table.path + deleteFileName;
+                        String deleteAbsPath = dataPath + deleteRelPath;
+
+                        DuckLakeDeleteExecutor.writeDeleteFile(deleteAbsPath, scanResult.deletePositions);
+
+                        long deleteFileSize = new File(deleteAbsPath).length();
+                        deleteResults.add(new DuckLakeDeleteExecutor.DeleteFileResult(
+                                dataFile.dataFileId, deleteRelPath,
+                                scanResult.deletePositions.size(), deleteFileSize));
+
+                        // Write new data file with updated rows
+                        String newFileName = "ducklake-" + UUID.randomUUID() + ".parquet";
+                        String newRelPath = table.path + newFileName;
+                        String newAbsPath = dataPath + newRelPath;
+
+                        writeUpdatedRows(newAbsPath, sparkSchema, columnIds,
+                                scanResult.updatedRows);
+
+                        long newFileSize = new File(newAbsPath).length();
+                        newDataFiles.add(new UpdateDataFileResult(
+                                newRelPath, scanResult.updatedRows.size(), newFileSize,
+                                scanResult.columnStats));
+                    }
+                }
+
+                if (deleteResults.isEmpty()) {
+                    backend.rollbackTransaction();
+                    return;
+                }
+
+                // Create new snapshot
+                long newSnap = currentSnap + 1;
+                long totalNewFiles = deleteResults.size() + newDataFiles.size();
+                long newNextFileId = nextFileId + totalNewFiles;
+                backend.createSnapshot(newSnap, snapInfo.schemaVersion,
+                        snapInfo.nextCatalogId, newNextFileId);
+
+                // Register delete files
+                long fileId = nextFileId;
+                long totalDeleteCount = 0;
+                for (DuckLakeDeleteExecutor.DeleteFileResult result : deleteResults) {
+                    backend.insertDeleteFile(fileId, table.tableId, newSnap,
+                            result.dataFileId, result.relativePath, result.deleteCount, result.fileSize);
+                    totalDeleteCount += result.deleteCount;
+                    fileId++;
+                }
+
+                // Register new data files
+                TableStats stats = backend.getTableStats(table.tableId);
+                long rowIdStart = stats.nextRowId;
+                long totalNewRecords = 0;
+                long totalNewFileSize = 0;
+                int fileOrder = 0;
+
+                for (UpdateDataFileResult ndf : newDataFiles) {
+                    backend.insertDataFile(fileId, table.tableId, newSnap, fileOrder,
+                            ndf.relativePath, ndf.recordCount, ndf.fileSize, rowIdStart);
+
+                    // Insert column stats
+                    for (DuckLakeWriterCommitMessage.ColumnStats cs : ndf.columnStats) {
+                        backend.insertColumnStats(fileId, table.tableId, cs.columnId,
+                                cs.valueCount, cs.nullCount, cs.minValue, cs.maxValue);
+                    }
+
+                    rowIdStart += ndf.recordCount;
+                    totalNewRecords += ndf.recordCount;
+                    totalNewFileSize += ndf.fileSize;
+                    fileId++;
+                    fileOrder++;
+                }
+
+                // Update table stats: subtract deleted, add new
+                long newRecordCount = stats.recordCount - totalDeleteCount + totalNewRecords;
+                backend.updateTableStats(table.tableId, newRecordCount, rowIdStart,
+                        stats.fileSizeBytes + totalNewFileSize);
+
+                backend.insertSnapshotChanges(newSnap,
+                        "deleted_from_table:" + table.tableId + ",inserted_into_table:" + table.tableId,
+                        "ducklake-spark", "Spark update");
+
+                backend.commitTransaction();
+            } catch (Exception e) {
+                try { backend.rollbackTransaction(); } catch (SQLException ex) { e.addSuppressed(ex); }
+                if (e instanceof RuntimeException) throw (RuntimeException) e;
+                throw new RuntimeException("Failed to execute update", e);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to execute update", e);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Scanning, updating, and writing
+    // ---------------------------------------------------------------
+
+    private ScanResult scanAndCollectUpdates(String filePath, StructType sparkSchema,
+                                              Filter[] filters, Set<Long> existingDeletes,
+                                              Map<String, String> logicalToPhysical,
+                                              Map<String, Object> updates,
+                                              long[] columnIds) {
+        List<Long> deletePositions = new ArrayList<>();
+        List<Object[]> updatedRows = new ArrayList<>();
+
+        // Initialize stats accumulators
+        StructField[] fields = sparkSchema.fields();
+        Comparable<?>[] mins = new Comparable<?>[fields.length];
+        Comparable<?>[] maxs = new Comparable<?>[fields.length];
+        long[] nullCounts = new long[fields.length];
+        long[] valueCounts = new long[fields.length];
+
+        try (ParquetFileReader reader = ParquetFileReader.open(new Configuration(), new Path(filePath))) {
+            MessageType fileSchema = reader.getFooter().getFileMetaData().getSchema();
+            DuckLakeRowFilterEvaluator evaluator =
+                    new DuckLakeRowFilterEvaluator(sparkSchema, fileSchema, logicalToPhysical);
+
+            long rowPosition = 0;
+            PageReadStore pages;
+            while ((pages = reader.readNextRowGroup()) != null) {
+                long rowCount = pages.getRowCount();
+                ColumnIOFactory factory = new ColumnIOFactory();
+                MessageColumnIO columnIO = factory.getColumnIO(fileSchema);
+                RecordReader<Group> recordReader =
+                        columnIO.getRecordReader(pages, new GroupRecordConverter(fileSchema));
+
+                for (long i = 0; i < rowCount; i++) {
+                    Group group = recordReader.read();
+                    long pos = rowPosition++;
+
+                    if (existingDeletes.contains(pos)) {
+                        continue;
+                    }
+
+                    if (evaluator.matches(group, filters)) {
+                        deletePositions.add(pos);
+
+                        // Build updated row
+                        Object[] rowValues = new Object[fields.length];
+                        for (int c = 0; c < fields.length; c++) {
+                            String colName = fields[c].name();
+                            if (updates.containsKey(colName)) {
+                                rowValues[c] = updates.get(colName);
+                            } else {
+                                rowValues[c] = readGroupValue(group, fileSchema,
+                                        logicalToPhysical, colName, fields[c].dataType());
+                            }
+
+                            // Track stats
+                            trackStats(rowValues[c], c, mins, maxs, nullCounts, valueCounts);
+                        }
+                        updatedRows.add(rowValues);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to scan file for update: " + filePath, e);
+        }
+
+        // Build column stats
+        List<DuckLakeWriterCommitMessage.ColumnStats> colStats = new ArrayList<>();
+        for (int c = 0; c < fields.length; c++) {
+            String minStr = mins[c] != null ? mins[c].toString() : null;
+            String maxStr = maxs[c] != null ? maxs[c].toString() : null;
+            colStats.add(new DuckLakeWriterCommitMessage.ColumnStats(
+                    columnIds[c], minStr, maxStr, nullCounts[c], valueCounts[c]));
+        }
+
+        return new ScanResult(deletePositions, updatedRows, colStats);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void trackStats(Object value, int colIdx,
+                             Comparable<?>[] mins, Comparable<?>[] maxs,
+                             long[] nullCounts, long[] valueCounts) {
+        if (value == null) {
+            nullCounts[colIdx]++;
+            return;
+        }
+        valueCounts[colIdx]++;
+        if (value instanceof Comparable) {
+            Comparable comp = (Comparable) value;
+            if (mins[colIdx] == null || comp.compareTo(mins[colIdx]) < 0) {
+                mins[colIdx] = comp;
+            }
+            if (maxs[colIdx] == null || comp.compareTo(maxs[colIdx]) > 0) {
+                maxs[colIdx] = comp;
+            }
+        }
+    }
+
+    private Object readGroupValue(Group group, MessageType fileSchema,
+                                   Map<String, String> logicalToPhysical,
+                                   String logicalName, DataType sparkType) {
+        String physicalName = logicalToPhysical.getOrDefault(logicalName, logicalName);
+        int fieldIndex;
+        try {
+            fieldIndex = fileSchema.getFieldIndex(physicalName);
+        } catch (Exception e) {
+            return null;
+        }
+        if (group.getFieldRepetitionCount(fieldIndex) == 0) {
+            return null;
+        }
+        try {
+            if (sparkType instanceof BooleanType) {
+                return group.getBoolean(fieldIndex, 0);
+            } else if (sparkType instanceof ByteType) {
+                return (byte) group.getInteger(fieldIndex, 0);
+            } else if (sparkType instanceof ShortType) {
+                return (short) group.getInteger(fieldIndex, 0);
+            } else if (sparkType instanceof IntegerType) {
+                return group.getInteger(fieldIndex, 0);
+            } else if (sparkType instanceof LongType) {
+                return group.getLong(fieldIndex, 0);
+            } else if (sparkType instanceof FloatType) {
+                return group.getFloat(fieldIndex, 0);
+            } else if (sparkType instanceof DoubleType) {
+                return group.getDouble(fieldIndex, 0);
+            } else if (sparkType instanceof StringType) {
+                return group.getString(fieldIndex, 0);
+            } else {
+                return group.getValueToString(fieldIndex, 0);
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void writeUpdatedRows(String absolutePath, StructType sparkSchema,
+                                   long[] columnIds, List<Object[]> rows) {
+        MessageType parquetSchema = buildParquetSchema(sparkSchema, columnIds);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(parquetSchema);
+
+        File parentDir = new File(absolutePath).getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+
+        try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(new Path(absolutePath))
+                .withType(parquetSchema)
+                .withConf(new Configuration())
+                .withWriteMode(ParquetFileWriter.Mode.CREATE)
+                .build()) {
+            StructField[] fields = sparkSchema.fields();
+            for (Object[] row : rows) {
+                Group group = groupFactory.newGroup();
+                for (int i = 0; i < fields.length; i++) {
+                    if (row[i] != null) {
+                        writeField(group, i, row[i], fields[i].dataType());
+                    }
+                }
+                writer.write(group);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write updated data file: " + absolutePath, e);
+        }
+    }
+
+    private void writeField(Group group, int fieldIndex, Object value, DataType type) {
+        if (type instanceof BooleanType) {
+            group.add(fieldIndex, (Boolean) value);
+        } else if (type instanceof ByteType) {
+            group.add(fieldIndex, (int) ((Byte) value));
+        } else if (type instanceof ShortType) {
+            group.add(fieldIndex, (int) ((Short) value));
+        } else if (type instanceof IntegerType) {
+            group.add(fieldIndex, (Integer) value);
+        } else if (type instanceof LongType) {
+            group.add(fieldIndex, (Long) value);
+        } else if (type instanceof FloatType) {
+            group.add(fieldIndex, (Float) value);
+        } else if (type instanceof DoubleType) {
+            group.add(fieldIndex, (Double) value);
+        } else if (type instanceof StringType) {
+            group.add(fieldIndex, value.toString());
+        } else {
+            group.add(fieldIndex, value.toString());
+        }
+    }
+
+    private static MessageType buildParquetSchema(StructType sparkSchema, long[] columnIds) {
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int i = 0; i < sparkSchema.fields().length; i++) {
+            StructField field = sparkSchema.fields()[i];
+            int fieldId = (int) columnIds[i];
+            builder.addField(sparkTypeToParquetType(field.name(), field.dataType(), field.nullable(), fieldId));
+        }
+        return builder.named("spark_schema");
+    }
+
+    private static org.apache.parquet.schema.Type sparkTypeToParquetType(
+            String name, DataType type, boolean nullable, int fieldId) {
+        PrimitiveType.PrimitiveTypeName typeName;
+        LogicalTypeAnnotation logicalType = null;
+
+        if (type instanceof BooleanType) {
+            typeName = PrimitiveType.PrimitiveTypeName.BOOLEAN;
+        } else if (type instanceof ByteType || type instanceof ShortType || type instanceof IntegerType) {
+            typeName = PrimitiveType.PrimitiveTypeName.INT32;
+        } else if (type instanceof LongType) {
+            typeName = PrimitiveType.PrimitiveTypeName.INT64;
+        } else if (type instanceof FloatType) {
+            typeName = PrimitiveType.PrimitiveTypeName.FLOAT;
+        } else if (type instanceof DoubleType) {
+            typeName = PrimitiveType.PrimitiveTypeName.DOUBLE;
+        } else {
+            typeName = PrimitiveType.PrimitiveTypeName.BINARY;
+            logicalType = LogicalTypeAnnotation.stringType();
+        }
+
+        if (logicalType != null) {
+            return nullable
+                    ? Types.optional(typeName).as(logicalType).id(fieldId).named(name)
+                    : Types.required(typeName).as(logicalType).id(fieldId).named(name);
+        } else {
+            return nullable
+                    ? Types.optional(typeName).id(fieldId).named(name)
+                    : Types.required(typeName).id(fieldId).named(name);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private Set<Long> loadExistingDeletes(DuckLakeMetadataBackend backend, long tableId,
+                                           long dataFileId, long snapshotId,
+                                           String dataPath) throws SQLException {
+        Set<Long> deleted = new HashSet<>();
+        List<DeleteFileInfo> deleteFiles = backend.getDeleteFiles(tableId, dataFileId, snapshotId);
+        for (DeleteFileInfo df : deleteFiles) {
+            String path = df.pathIsRelative ? dataPath + df.path : df.path;
+            try (ParquetFileReader reader = ParquetFileReader.open(new Configuration(), new Path(path))) {
+                MessageType schema = reader.getFooter().getFileMetaData().getSchema();
+                PageReadStore pages;
+                while ((pages = reader.readNextRowGroup()) != null) {
+                    ColumnIOFactory factory = new ColumnIOFactory();
+                    MessageColumnIO columnIO = factory.getColumnIO(schema);
+                    RecordReader<Group> recordReader =
+                            columnIO.getRecordReader(pages, new GroupRecordConverter(schema));
+                    for (long i = 0; i < pages.getRowCount(); i++) {
+                        Group group = recordReader.read();
+                        int fieldIdx = schema.getFieldIndex("row_id");
+                        deleted.add(group.getLong(fieldIdx, 0));
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to read delete file: " + path, e);
+            }
+        }
+        return deleted;
+    }
+
+    private Map<String, String> buildLogicalToPhysical(DuckLakeMetadataBackend backend,
+                                                         long mappingId,
+                                                         Map<Long, String> colIdToName) throws SQLException {
+        Map<String, String> logicalToPhysical = new HashMap<>();
+        if (mappingId >= 0) {
+            Map<Long, String> nameMapping = backend.getNameMapping(mappingId);
+            for (Map.Entry<Long, String> entry : nameMapping.entrySet()) {
+                long fieldId = entry.getKey();
+                String physicalName = entry.getValue();
+                String logicalName = colIdToName.get(fieldId);
+                if (logicalName != null && !physicalName.equals(logicalName)) {
+                    logicalToPhysical.put(logicalName, physicalName);
+                }
+            }
+        }
+        return logicalToPhysical;
+    }
+
+    private DuckLakeMetadataBackend createBackend() {
+        return new DuckLakeMetadataBackend(catalogPath, dataPathOption);
+    }
+
+    // ---------------------------------------------------------------
+    // Result data classes
+    // ---------------------------------------------------------------
+
+    private static class ScanResult {
+        final List<Long> deletePositions;
+        final List<Object[]> updatedRows;
+        final List<DuckLakeWriterCommitMessage.ColumnStats> columnStats;
+
+        ScanResult(List<Long> deletePositions, List<Object[]> updatedRows,
+                   List<DuckLakeWriterCommitMessage.ColumnStats> columnStats) {
+            this.deletePositions = deletePositions;
+            this.updatedRows = updatedRows;
+            this.columnStats = columnStats;
+        }
+    }
+
+    private static class UpdateDataFileResult {
+        final String relativePath;
+        final long recordCount;
+        final long fileSize;
+        final List<DuckLakeWriterCommitMessage.ColumnStats> columnStats;
+
+        UpdateDataFileResult(String relativePath, long recordCount, long fileSize,
+                              List<DuckLakeWriterCommitMessage.ColumnStats> columnStats) {
+            this.relativePath = relativePath;
+            this.recordCount = recordCount;
+            this.fileSize = fileSize;
+            this.columnStats = columnStats;
+        }
+    }
+}

--- a/src/test/java/io/ducklake/spark/DuckLakeDeleteTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeDeleteTest.java
@@ -1,0 +1,464 @@
+package io.ducklake.spark;
+
+import io.ducklake.spark.writer.DuckLakeUpdateExecutor;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.junit.*;
+
+import java.io.File;
+import java.nio.file.*;
+import java.sql.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for DuckLake row-level delete and update operations.
+ */
+public class DuckLakeDeleteTest {
+
+    private static SparkSession spark;
+    private static String tempDir;
+    private static String catalogPath;
+    private static String dataPath;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        tempDir = Files.createTempDirectory("ducklake-delete-test-").toString();
+        dataPath = tempDir + "/data/";
+        new File(dataPath).mkdirs();
+        catalogPath = tempDir + "/test.ducklake";
+        createMinimalCatalog(catalogPath, dataPath);
+
+        Thread.currentThread().setContextClassLoader(DuckLakeDeleteTest.class.getClassLoader());
+
+        spark = SparkSession.builder()
+                .master("local[2]")
+                .appName("DuckLakeDeleteTest")
+                .config("spark.ui.enabled", "false")
+                .config("spark.driver.host", "localhost")
+                .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
+                .config("spark.sql.catalog.ducklake.catalog", catalogPath)
+                .config("spark.sql.catalog.ducklake.data_path", dataPath)
+                .getOrCreate();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (spark != null) {
+            spark.stop();
+            spark = null;
+        }
+        if (tempDir != null) {
+            deleteRecursive(new File(tempDir));
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Helper: insert test data via SQL
+    // ---------------------------------------------------------------
+
+    private void createAndPopulateTable(String tableName, int numRows) {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main." + tableName +
+                " (id INT, name STRING, value DOUBLE)");
+
+        StringBuilder values = new StringBuilder();
+        for (int i = 1; i <= numRows; i++) {
+            if (i > 1) values.append(", ");
+            values.append("(").append(i).append(", 'name_").append(i).append("', ").append(i * 10.0).append(")");
+        }
+        spark.sql("INSERT INTO ducklake.main." + tableName + " VALUES " + values);
+    }
+
+    // ---------------------------------------------------------------
+    // DELETE tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testDeleteByPredicate() {
+        createAndPopulateTable("del_pred", 5);
+
+        // Verify initial data
+        assertEquals(5, spark.sql("SELECT * FROM ducklake.main.del_pred").count());
+
+        // Delete rows where id > 3
+        spark.sql("DELETE FROM ducklake.main.del_pred WHERE id > 3");
+
+        // Verify remaining rows
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_pred ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(2, rows.get(1).getInt(0));
+        assertEquals(3, rows.get(2).getInt(0));
+    }
+
+    @Test
+    public void testDeleteAllRows() {
+        createAndPopulateTable("del_all", 3);
+        assertEquals(3, spark.sql("SELECT * FROM ducklake.main.del_all").count());
+
+        // Delete all rows
+        spark.sql("DELETE FROM ducklake.main.del_all WHERE id >= 1");
+
+        assertEquals(0, spark.sql("SELECT * FROM ducklake.main.del_all").count());
+    }
+
+    @Test
+    public void testDeleteNoMatch() {
+        createAndPopulateTable("del_nomatch", 3);
+
+        // Delete with non-matching predicate — should be a no-op
+        spark.sql("DELETE FROM ducklake.main.del_nomatch WHERE id > 100");
+
+        assertEquals(3, spark.sql("SELECT * FROM ducklake.main.del_nomatch").count());
+    }
+
+    @Test
+    public void testDeleteByStringPredicate() {
+        createAndPopulateTable("del_str", 5);
+
+        // Delete by string equality
+        spark.sql("DELETE FROM ducklake.main.del_str WHERE name = 'name_3'");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_str ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(4, rows.size());
+
+        // Verify name_3 is gone
+        for (Row row : rows) {
+            assertNotEquals("name_3", row.getString(1));
+        }
+    }
+
+    @Test
+    public void testDeleteWithCompoundPredicate() {
+        createAndPopulateTable("del_compound", 5);
+
+        // Delete rows where id <= 2 OR id = 5
+        spark.sql("DELETE FROM ducklake.main.del_compound WHERE id <= 2 OR id = 5");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_compound ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(2, rows.size());
+        assertEquals(3, rows.get(0).getInt(0));
+        assertEquals(4, rows.get(1).getInt(0));
+    }
+
+    @Test
+    public void testMultipleDeletesOnSameTable() {
+        createAndPopulateTable("del_multi", 5);
+
+        // First delete
+        spark.sql("DELETE FROM ducklake.main.del_multi WHERE id = 1");
+        assertEquals(4, spark.sql("SELECT * FROM ducklake.main.del_multi").count());
+
+        // Second delete
+        spark.sql("DELETE FROM ducklake.main.del_multi WHERE id = 3");
+        assertEquals(3, spark.sql("SELECT * FROM ducklake.main.del_multi").count());
+
+        // Third delete
+        spark.sql("DELETE FROM ducklake.main.del_multi WHERE id = 5");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_multi ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(2, rows.size());
+        assertEquals(2, rows.get(0).getInt(0));
+        assertEquals(4, rows.get(1).getInt(0));
+    }
+
+    @Test
+    public void testDeleteThenInsert() {
+        createAndPopulateTable("del_ins", 3);
+
+        // Delete some rows
+        spark.sql("DELETE FROM ducklake.main.del_ins WHERE id = 2");
+
+        // Insert new data
+        spark.sql("INSERT INTO ducklake.main.del_ins VALUES (10, 'new_row', 100.0)");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_ins ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(3, rows.get(1).getInt(0));
+        assertEquals(10, rows.get(2).getInt(0));
+    }
+
+    @Test
+    public void testDeleteUpdatesTableStats() throws Exception {
+        createAndPopulateTable("del_stats", 5);
+
+        spark.sql("DELETE FROM ducklake.main.del_stats WHERE id > 3");
+
+        // Check table stats in catalog
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catalogPath)) {
+            // Find the table_id
+            long tableId;
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT table_id FROM ducklake_table WHERE table_name = 'del_stats' AND end_snapshot IS NULL")) {
+                ResultSet rs = ps.executeQuery();
+                assertTrue(rs.next());
+                tableId = rs.getLong(1);
+            }
+
+            // Check record count was updated
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT record_count FROM ducklake_table_stats WHERE table_id = ?")) {
+                ps.setLong(1, tableId);
+                ResultSet rs = ps.executeQuery();
+                assertTrue(rs.next());
+                assertEquals(3, rs.getLong("record_count"));
+            }
+
+            // Check delete file was registered
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT COUNT(*) FROM ducklake_delete_file WHERE table_id = ? AND end_snapshot IS NULL")) {
+                ps.setLong(1, tableId);
+                ResultSet rs = ps.executeQuery();
+                assertTrue(rs.next());
+                assertTrue("Should have at least one delete file", rs.getInt(1) >= 1);
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteCreatesNewSnapshot() throws Exception {
+        createAndPopulateTable("del_snap", 3);
+
+        // Get current snapshot before delete
+        long snapBefore;
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catalogPath)) {
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT MAX(snapshot_id) FROM ducklake_snapshot")) {
+                rs.next();
+                snapBefore = rs.getLong(1);
+            }
+        }
+
+        spark.sql("DELETE FROM ducklake.main.del_snap WHERE id = 1");
+
+        // Verify new snapshot was created
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catalogPath)) {
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT MAX(snapshot_id) FROM ducklake_snapshot")) {
+                rs.next();
+                assertTrue("Delete should create new snapshot", rs.getLong(1) > snapBefore);
+            }
+
+            // Verify snapshot changes reference the delete
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery(
+                     "SELECT changes_made FROM ducklake_snapshot_changes WHERE snapshot_id = " +
+                     "(SELECT MAX(snapshot_id) FROM ducklake_snapshot)")) {
+                assertTrue(rs.next());
+                assertTrue("Should record delete changes",
+                        rs.getString("changes_made").contains("deleted_from_table"));
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteByDoublePredicate() {
+        createAndPopulateTable("del_dbl", 5);
+
+        // Delete where value > 30.0
+        spark.sql("DELETE FROM ducklake.main.del_dbl WHERE value > 30.0");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_dbl ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(2, rows.get(1).getInt(0));
+        assertEquals(3, rows.get(2).getInt(0));
+    }
+
+    // ---------------------------------------------------------------
+    // UPDATE tests (via DuckLakeUpdateExecutor)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testUpdateRows() {
+        createAndPopulateTable("upd_basic", 5);
+
+        // Update name where id > 3
+        DuckLakeUpdateExecutor updater = new DuckLakeUpdateExecutor(
+                catalogPath, dataPath, "upd_basic", "main");
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("name", "updated");
+
+        org.apache.spark.sql.sources.Filter filter =
+                new org.apache.spark.sql.sources.GreaterThan("id", 3);
+        updater.updateWhere(new org.apache.spark.sql.sources.Filter[]{filter}, updates);
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.upd_basic ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(5, rows.size());
+
+        // First 3 rows unchanged
+        for (int i = 0; i < 3; i++) {
+            assertEquals("name_" + (i + 1), rows.get(i).getString(1));
+        }
+        // Last 2 rows updated
+        assertEquals("updated", rows.get(3).getString(1));
+        assertEquals("updated", rows.get(4).getString(1));
+
+        // id and value should be preserved
+        assertEquals(4, rows.get(3).getInt(0));
+        assertEquals(5, rows.get(4).getInt(0));
+        assertEquals(40.0, rows.get(3).getDouble(2), 0.001);
+        assertEquals(50.0, rows.get(4).getDouble(2), 0.001);
+    }
+
+    @Test
+    public void testUpdateMultipleColumns() {
+        createAndPopulateTable("upd_multi", 3);
+
+        DuckLakeUpdateExecutor updater = new DuckLakeUpdateExecutor(
+                catalogPath, dataPath, "upd_multi", "main");
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("name", "changed");
+        updates.put("value", 999.0);
+
+        org.apache.spark.sql.sources.Filter filter =
+                new org.apache.spark.sql.sources.EqualTo("id", 2);
+        updater.updateWhere(new org.apache.spark.sql.sources.Filter[]{filter}, updates);
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.upd_multi ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+
+        // Row 2 should be updated
+        assertEquals(2, rows.get(1).getInt(0));
+        assertEquals("changed", rows.get(1).getString(1));
+        assertEquals(999.0, rows.get(1).getDouble(2), 0.001);
+
+        // Other rows unchanged
+        assertEquals("name_1", rows.get(0).getString(1));
+        assertEquals("name_3", rows.get(2).getString(1));
+    }
+
+    @Test
+    public void testUpdateNoMatch() {
+        createAndPopulateTable("upd_nomatch", 3);
+
+        DuckLakeUpdateExecutor updater = new DuckLakeUpdateExecutor(
+                catalogPath, dataPath, "upd_nomatch", "main");
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("name", "should_not_exist");
+
+        org.apache.spark.sql.sources.Filter filter =
+                new org.apache.spark.sql.sources.EqualTo("id", 999);
+        updater.updateWhere(new org.apache.spark.sql.sources.Filter[]{filter}, updates);
+
+        // Should be unchanged
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.upd_nomatch ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+        for (Row row : rows) {
+            assertNotEquals("should_not_exist", row.getString(1));
+        }
+    }
+
+    @Test
+    public void testUpdateThenDelete() {
+        createAndPopulateTable("upd_del", 5);
+
+        // First: update some rows
+        DuckLakeUpdateExecutor updater = new DuckLakeUpdateExecutor(
+                catalogPath, dataPath, "upd_del", "main");
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("name", "updated");
+        org.apache.spark.sql.sources.Filter filter =
+                new org.apache.spark.sql.sources.LessThanOrEqual("id", 2);
+        updater.updateWhere(new org.apache.spark.sql.sources.Filter[]{filter}, updates);
+
+        // Then: delete some rows (including an updated one)
+        spark.sql("DELETE FROM ducklake.main.upd_del WHERE id = 1");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.upd_del ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(4, rows.size());
+
+        // id=2 should have updated name
+        assertEquals(2, rows.get(0).getInt(0));
+        assertEquals("updated", rows.get(0).getString(1));
+
+        // id=3,4,5 should be original
+        assertEquals(3, rows.get(1).getInt(0));
+        assertEquals("name_3", rows.get(1).getString(1));
+    }
+
+    @Test
+    public void testDeleteAfterUpdate() {
+        createAndPopulateTable("del_after_upd", 3);
+
+        // Update row 2
+        DuckLakeUpdateExecutor updater = new DuckLakeUpdateExecutor(
+                catalogPath, dataPath, "del_after_upd", "main");
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("value", 999.0);
+        org.apache.spark.sql.sources.Filter filter =
+                new org.apache.spark.sql.sources.EqualTo("id", 2);
+        updater.updateWhere(new org.apache.spark.sql.sources.Filter[]{filter}, updates);
+
+        // Now delete the updated row
+        spark.sql("DELETE FROM ducklake.main.del_after_upd WHERE value > 500.0");
+
+        Dataset<Row> result = spark.sql("SELECT * FROM ducklake.main.del_after_upd ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(2, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(3, rows.get(1).getInt(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Catalog setup helper (minimal)
+    // ---------------------------------------------------------------
+
+    private static void createMinimalCatalog(String catPath, String dp) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catPath)) {
+            conn.setAutoCommit(false);
+            try (Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY, snapshot_time TEXT, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot_changes(snapshot_id BIGINT PRIMARY KEY, changes_made VARCHAR, author VARCHAR, commit_message VARCHAR, commit_extra_info VARCHAR)");
+                st.execute("CREATE TABLE ducklake_schema(schema_id BIGINT PRIMARY KEY, schema_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_table(table_id BIGINT, table_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_id BIGINT, table_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_column(column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR, column_type VARCHAR, initial_default VARCHAR, default_value VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR)");
+                st.execute("CREATE TABLE ducklake_data_file(data_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, file_order BIGINT, path VARCHAR, path_is_relative BOOLEAN, file_format VARCHAR, record_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, row_id_start BIGINT, partition_id BIGINT, encryption_key VARCHAR, mapping_id BIGINT, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_column_stats(data_file_id BIGINT, table_id BIGINT, column_id BIGINT, column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN, extra_stats VARCHAR)");
+                st.execute("CREATE TABLE ducklake_table_stats(table_id BIGINT, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT)");
+                st.execute("CREATE TABLE ducklake_delete_file(delete_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, format VARCHAR, delete_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, encryption_key VARCHAR, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)");
+
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('version', '0.4')");
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('data_path', '" + dp + "')");
+
+                st.execute("INSERT INTO ducklake_snapshot VALUES (0, datetime('now'), 0, 1, 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (0, 'created_schema:\"main\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', 'main/', 1)");
+            }
+            conn.commit();
+        }
+    }
+
+    private static void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
## Row-Level Delete + Update Operations

Implements deletion vector support for row-level operations in the DuckLake Spark connector. Part of the roadmap in #1.

### DELETE (SQL support via `SupportsDelete`)

```sql
DELETE FROM ducklake.main.my_table WHERE id > 5
DELETE FROM ducklake.main.my_table WHERE name = 'old'
```

- `DuckLakeDeleteExecutor` scans data files, evaluates WHERE predicates against individual rows using `DuckLakeRowFilterEvaluator`
- Writes delete files (Parquet with `row_id` column) — the standard DuckLake deletion vector format
- Both `DuckLakeTable` and `DuckLakeCatalogTable` implement `SupportsDelete`
- Creates new snapshot, registers delete files in catalog, updates table stats
- Handles existing delete files (won't re-delete already-deleted rows)

### UPDATE (via `DuckLakeUpdateExecutor`)

Copy-on-write approach:
1. Scan data files and evaluate WHERE predicate
2. Write delete files for matching rows (marks old version as deleted)
3. Write new data files with updated column values
4. Register both in catalog with proper stats

### Backend additions

- `insertDeleteFile()` — register delete files in `ducklake_delete_file`
- `markDeleteFilesDeleted()` — cleanup during table drops
- `dropTableEntry` now properly marks delete files as deleted

### New classes

| Class | Purpose |
|-------|---------|
| `DuckLakeDeleteExecutor` | Core delete logic with predicate evaluation |
| `DuckLakeUpdateExecutor` | Delete + re-insert for row updates |
| `DuckLakeRowFilterEvaluator` | Row-level Spark Filter evaluation against Parquet Groups |

### Tests (15 new, 84 total passing)

- Delete by predicate (int, double, string equality)
- Delete all rows / no matching rows (no-op)
- Compound predicates (AND, OR)
- Multiple sequential deletes on same table
- Delete then insert (verify coexistence)
- Snapshot creation and table stats verification
- Update single/multiple columns
- Update with no match (no-op)
- Combined update + delete sequences

Refs #1