### PR TITLE
feat: add complex type write/read support (ARRAY, STRUCT, MAP)

### DIFF
--- a/src/main/java/io/ducklake/spark/reader/DuckLakePartitionReader.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakePartitionReader.java
@@ -2,6 +2,8 @@ package io.ducklake.spark.reader;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
+import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -289,6 +291,48 @@ public class DuckLakePartitionReader implements PartitionReader<InternalRow> {
                 d.set(new scala.math.BigDecimal(bd), dt.precision(), dt.scale());
                 return d;
             }
+        } else if (sparkType instanceof ArrayType) {
+            ArrayType at = (ArrayType) sparkType;
+            Group listGroup = group.getGroup(fieldIndex, 0);
+            int listSize = listGroup.getFieldRepetitionCount(0); // "list" repeated group count
+            Object[] elements = new Object[listSize];
+            for (int j = 0; j < listSize; j++) {
+                Group elementGroup = listGroup.getGroup(0, j);
+                if (elementGroup.getFieldRepetitionCount(0) == 0) {
+                    elements[j] = null; // null element
+                } else {
+                    elements[j] = readValue(elementGroup, 0, at.elementType());
+                }
+            }
+            return new GenericArrayData(elements);
+        } else if (sparkType instanceof StructType) {
+            StructType st = (StructType) sparkType;
+            Group structGroup = group.getGroup(fieldIndex, 0);
+            Object[] values = new Object[st.fields().length];
+            for (int j = 0; j < st.fields().length; j++) {
+                if (structGroup.getFieldRepetitionCount(j) == 0) {
+                    values[j] = null;
+                } else {
+                    values[j] = readValue(structGroup, j, st.fields()[j].dataType());
+                }
+            }
+            return new GenericInternalRow(values);
+        } else if (sparkType instanceof MapType) {
+            MapType mt = (MapType) sparkType;
+            Group mapGroup = group.getGroup(fieldIndex, 0);
+            int mapSize = mapGroup.getFieldRepetitionCount(0); // "key_value" repeated group count
+            Object[] keys = new Object[mapSize];
+            Object[] values = new Object[mapSize];
+            for (int j = 0; j < mapSize; j++) {
+                Group kvGroup = mapGroup.getGroup(0, j);
+                keys[j] = readValue(kvGroup, 0, mt.keyType());
+                if (kvGroup.getFieldRepetitionCount(1) == 0) {
+                    values[j] = null;
+                } else {
+                    values[j] = readValue(kvGroup, 1, mt.valueType());
+                }
+            }
+            return new ArrayBasedMapData(new GenericArrayData(keys), new GenericArrayData(values));
         } else {
             return UTF8String.fromString(group.getValueToString(fieldIndex, 0));
         }

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeDataWriter.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeDataWriter.java
@@ -5,6 +5,9 @@ import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.types.*;
 
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.example.data.Group;
@@ -187,6 +190,60 @@ public class DuckLakeDataWriter implements DataWriter<InternalRow> {
                             .id(fieldId).named(name);
                 }
             }
+        } else if (type instanceof ArrayType) {
+            // Standard 3-level Parquet LIST encoding
+            ArrayType at = (ArrayType) type;
+            org.apache.parquet.schema.Type elementType =
+                    sparkTypeToParquetType("element", at.elementType(), at.containsNull(), 0);
+            GroupType repeatedList = Types.repeatedGroup()
+                    .addField(elementType)
+                    .named("list");
+            if (nullable) {
+                return Types.optionalGroup()
+                        .as(LogicalTypeAnnotation.listType())
+                        .addField(repeatedList)
+                        .id(fieldId)
+                        .named(name);
+            } else {
+                return Types.requiredGroup()
+                        .as(LogicalTypeAnnotation.listType())
+                        .addField(repeatedList)
+                        .id(fieldId)
+                        .named(name);
+            }
+        } else if (type instanceof StructType) {
+            StructType st = (StructType) type;
+            Types.GroupBuilder<GroupType> builder = nullable
+                    ? Types.optionalGroup() : Types.requiredGroup();
+            for (int i = 0; i < st.fields().length; i++) {
+                StructField f = st.fields()[i];
+                builder.addField(sparkTypeToParquetType(f.name(), f.dataType(), f.nullable(), 0));
+            }
+            return builder.id(fieldId).named(name);
+        } else if (type instanceof MapType) {
+            // Standard Parquet MAP encoding
+            MapType mt = (MapType) type;
+            org.apache.parquet.schema.Type keyType =
+                    sparkTypeToParquetType("key", mt.keyType(), false, 0);
+            org.apache.parquet.schema.Type valueType =
+                    sparkTypeToParquetType("value", mt.valueType(), mt.valueContainsNull(), 0);
+            GroupType repeatedKeyValue = Types.repeatedGroup()
+                    .addField(keyType)
+                    .addField(valueType)
+                    .named("key_value");
+            if (nullable) {
+                return Types.optionalGroup()
+                        .as(LogicalTypeAnnotation.mapType())
+                        .addField(repeatedKeyValue)
+                        .id(fieldId)
+                        .named(name);
+            } else {
+                return Types.requiredGroup()
+                        .as(LogicalTypeAnnotation.mapType())
+                        .addField(repeatedKeyValue)
+                        .id(fieldId)
+                        .named(name);
+            }
         }
         // Fallback: store as string
         return primitive(nullable, PrimitiveTypeName.BINARY,
@@ -211,7 +268,7 @@ public class DuckLakeDataWriter implements DataWriter<InternalRow> {
     }
 
     // ---------------------------------------------------------------
-    // InternalRow → Parquet Group conversion
+    // InternalRow -> Parquet Group conversion
     // ---------------------------------------------------------------
 
     private Object writeField(Group group, int fieldIndex, InternalRow row, int ordinal, DataType type) {
@@ -281,11 +338,136 @@ public class DuckLakeDataWriter implements DataWriter<InternalRow> {
                 group.add(fieldIndex, Binary.fromConstantByteArray(padded));
                 return null; // skip stats for large decimals
             }
+        } else if (type instanceof ArrayType) {
+            ArrayType at = (ArrayType) type;
+            ArrayData arrayData = row.getArray(ordinal);
+            writeArrayToGroup(group, fieldIndex, arrayData, at.elementType());
+            return null; // skip stats for complex types
+        } else if (type instanceof StructType) {
+            StructType st = (StructType) type;
+            InternalRow structRow = row.getStruct(ordinal, st.fields().length);
+            writeStructToGroup(group, fieldIndex, structRow, st);
+            return null; // skip stats for complex types
+        } else if (type instanceof MapType) {
+            MapType mt = (MapType) type;
+            MapData mapData = row.getMap(ordinal);
+            writeMapToGroup(group, fieldIndex, mapData, mt.keyType(), mt.valueType());
+            return null; // skip stats for complex types
         }
         // Fallback: write as string
         String v = row.get(ordinal, type).toString();
         group.add(fieldIndex, v);
         return v;
+    }
+
+    // ---------------------------------------------------------------
+    // Complex type writers
+    // ---------------------------------------------------------------
+
+    /**
+     * Write an ArrayData as a Parquet LIST group (3-level encoding).
+     * Schema: group (LIST) { repeated group list { optional element } }
+     */
+    private void writeArrayToGroup(Group parentGroup, int fieldIndex,
+                                    ArrayData arrayData, DataType elementType) {
+        Group listGroup = parentGroup.addGroup(fieldIndex);
+        for (int j = 0; j < arrayData.numElements(); j++) {
+            Group elementGroup = listGroup.addGroup(0); // "list" repeated group
+            if (!arrayData.isNullAt(j)) {
+                writeValueFromArrayData(elementGroup, 0, arrayData, j, elementType);
+            }
+            // null elements: the optional "element" field is simply not populated
+        }
+    }
+
+    /**
+     * Write an InternalRow (struct) as a Parquet group with named fields.
+     */
+    private void writeStructToGroup(Group parentGroup, int fieldIndex,
+                                     InternalRow structRow, StructType structType) {
+        Group structGroup = parentGroup.addGroup(fieldIndex);
+        for (int j = 0; j < structType.fields().length; j++) {
+            if (!structRow.isNullAt(j)) {
+                writeField(structGroup, j, structRow, j, structType.fields()[j].dataType());
+            }
+        }
+    }
+
+    /**
+     * Write a MapData as a Parquet MAP group.
+     * Schema: group (MAP) { repeated group key_value { required key; optional value } }
+     */
+    private void writeMapToGroup(Group parentGroup, int fieldIndex,
+                                  MapData mapData, DataType keyType, DataType valueType) {
+        Group mapGroup = parentGroup.addGroup(fieldIndex);
+        ArrayData keys = mapData.keyArray();
+        ArrayData values = mapData.valueArray();
+        for (int j = 0; j < mapData.numElements(); j++) {
+            Group kvGroup = mapGroup.addGroup(0); // "key_value" repeated group
+            writeValueFromArrayData(kvGroup, 0, keys, j, keyType);
+            if (!values.isNullAt(j)) {
+                writeValueFromArrayData(kvGroup, 1, values, j, valueType);
+            }
+        }
+    }
+
+    /**
+     * Write a single value from an ArrayData to a Parquet Group field.
+     * Handles all primitive types and recurses for nested complex types.
+     */
+    private void writeValueFromArrayData(Group group, int fieldIndex,
+                                          ArrayData array, int ordinal, DataType type) {
+        if (type instanceof BooleanType) {
+            group.add(fieldIndex, array.getBoolean(ordinal));
+        } else if (type instanceof ByteType) {
+            group.add(fieldIndex, (int) array.getByte(ordinal));
+        } else if (type instanceof ShortType) {
+            group.add(fieldIndex, (int) array.getShort(ordinal));
+        } else if (type instanceof IntegerType) {
+            group.add(fieldIndex, array.getInt(ordinal));
+        } else if (type instanceof LongType) {
+            group.add(fieldIndex, array.getLong(ordinal));
+        } else if (type instanceof FloatType) {
+            group.add(fieldIndex, array.getFloat(ordinal));
+        } else if (type instanceof DoubleType) {
+            group.add(fieldIndex, array.getDouble(ordinal));
+        } else if (type instanceof StringType) {
+            group.add(fieldIndex, array.getUTF8String(ordinal).toString());
+        } else if (type instanceof BinaryType) {
+            group.add(fieldIndex, Binary.fromReusedByteArray(array.getBinary(ordinal)));
+        } else if (type instanceof DateType) {
+            group.add(fieldIndex, array.getInt(ordinal));
+        } else if (type instanceof TimestampType) {
+            group.add(fieldIndex, array.getLong(ordinal));
+        } else if (type instanceof DecimalType) {
+            DecimalType dt = (DecimalType) type;
+            org.apache.spark.sql.types.Decimal dec = array.getDecimal(ordinal, dt.precision(), dt.scale());
+            if (dt.precision() <= 9) {
+                group.add(fieldIndex, (int) dec.toUnscaledLong());
+            } else if (dt.precision() <= 18) {
+                group.add(fieldIndex, dec.toUnscaledLong());
+            } else {
+                byte[] unscaled = dec.toJavaBigDecimal().unscaledValue().toByteArray();
+                int byteLen = computeDecimalByteLength(dt.precision());
+                byte[] padded = new byte[byteLen];
+                if (unscaled[0] < 0) {
+                    Arrays.fill(padded, (byte) 0xFF);
+                }
+                System.arraycopy(unscaled, 0, padded, padded.length - unscaled.length, unscaled.length);
+                group.add(fieldIndex, Binary.fromConstantByteArray(padded));
+            }
+        } else if (type instanceof ArrayType) {
+            ArrayType at = (ArrayType) type;
+            writeArrayToGroup(group, fieldIndex, array.getArray(ordinal), at.elementType());
+        } else if (type instanceof StructType) {
+            StructType st = (StructType) type;
+            writeStructToGroup(group, fieldIndex, array.getStruct(ordinal, st.fields().length), st);
+        } else if (type instanceof MapType) {
+            MapType mt = (MapType) type;
+            writeMapToGroup(group, fieldIndex, array.getMap(ordinal), mt.keyType(), mt.valueType());
+        } else {
+            group.add(fieldIndex, array.get(ordinal, type).toString());
+        }
     }
 
     // ---------------------------------------------------------------
@@ -310,7 +492,7 @@ public class DuckLakeDataWriter implements DataWriter<InternalRow> {
         @SuppressWarnings({"unchecked", "rawtypes"})
         void addValue(Object value) {
             if (value == null) {
-                // Binary or unsupported type - track count only
+                // Binary, complex, or unsupported type - track count only
                 valueCount++;
                 return;
             }

--- a/src/test/java/io/ducklake/spark/DuckLakeIntegrationTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeIntegrationTest.java
@@ -371,8 +371,6 @@ public class DuckLakeIntegrationTest {
         assertArrayEquals(new byte[]{(byte) 0x00, (byte) 0xFF}, (byte[]) r1.get(4));
     }
 
-    @Ignore("Complex types (ARRAY, STRUCT, MAP) are written as strings by the Parquet writer fallback. " +
-            "Proper nested type support requires implementing Group-based Parquet read/write for these types.")
     @Test
     public void testTypeRoundTripComplexTypes() {
         spark.sql("CREATE TABLE ducklake.main.types_complex (" +
@@ -415,6 +413,147 @@ public class DuckLakeIntegrationTest {
     }
 
     // ===============================================================
+
+    @Test
+    public void testArrayWithNulls() {
+        spark.sql("CREATE TABLE ducklake.main.arr_nulls (id INT, vals ARRAY<STRING>)");
+
+        spark.sql("INSERT INTO ducklake.main.arr_nulls VALUES " +
+                "(1, array('hello', null, 'world')), " +
+                "(2, array(null, null)), " +
+                "(3, null)");
+
+        Dataset<Row> result = spark.sql(
+                "SELECT id, vals[0], vals[1], vals[2], size(vals) " +
+                "FROM ducklake.main.arr_nulls ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+
+        // Row 1: ['hello', null, 'world']
+        assertEquals("hello", rows.get(0).getString(1));
+        assertTrue(rows.get(0).isNullAt(2));
+        assertEquals("world", rows.get(0).getString(3));
+        assertEquals(3, rows.get(0).getInt(4));
+
+        // Row 2: [null, null]
+        assertTrue(rows.get(1).isNullAt(1));
+        assertTrue(rows.get(1).isNullAt(2));
+        assertEquals(2, rows.get(1).getInt(4));
+
+        // Row 3: null array -> size returns -1
+        assertEquals(-1, rows.get(2).getInt(4));
+    }
+
+    @Test
+    public void testStructWithMultipleFields() {
+        spark.sql("CREATE TABLE ducklake.main.struct_multi (" +
+                "id INT, " +
+                "info STRUCT<name: STRING, score: DOUBLE, active: BOOLEAN>)");
+
+        spark.sql("INSERT INTO ducklake.main.struct_multi VALUES " +
+                "(1, named_struct('name', 'alice', 'score', 95.5, 'active', true)), " +
+                "(2, named_struct('name', 'bob', 'score', 82.3, 'active', false)), " +
+                "(3, null)");
+
+        Dataset<Row> result = spark.sql(
+                "SELECT id, info.name, info.score, info.active " +
+                "FROM ducklake.main.struct_multi ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+
+        assertEquals("alice", rows.get(0).getString(1));
+        assertEquals(95.5, rows.get(0).getDouble(2), 0.001);
+        assertTrue(rows.get(0).getBoolean(3));
+
+        assertEquals("bob", rows.get(1).getString(1));
+        assertEquals(82.3, rows.get(1).getDouble(2), 0.001);
+        assertFalse(rows.get(1).getBoolean(3));
+
+        // Row 3: null struct
+        assertTrue(rows.get(2).isNullAt(1));
+        assertTrue(rows.get(2).isNullAt(2));
+        assertTrue(rows.get(2).isNullAt(3));
+    }
+
+    @Test
+    public void testMapWithVariousTypes() {
+        spark.sql("CREATE TABLE ducklake.main.map_types (" +
+                "id INT, " +
+                "scores MAP<STRING, DOUBLE>)");
+
+        spark.sql("INSERT INTO ducklake.main.map_types VALUES " +
+                "(1, map('math', 95.0, 'english', 88.5)), " +
+                "(2, map('science', 72.0)), " +
+                "(3, null)");
+
+        Dataset<Row> result = spark.sql(
+                "SELECT id, scores['math'], scores['english'], scores['science'] " +
+                "FROM ducklake.main.map_types ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+
+        assertEquals(95.0, rows.get(0).getDouble(1), 0.001);
+        assertEquals(88.5, rows.get(0).getDouble(2), 0.001);
+        assertTrue(rows.get(0).isNullAt(3)); // 'science' not in row 1
+
+        assertTrue(rows.get(1).isNullAt(1)); // 'math' not in row 2
+        assertTrue(rows.get(1).isNullAt(2)); // 'english' not in row 2
+        assertEquals(72.0, rows.get(1).getDouble(3), 0.001);
+
+        // Row 3: null map
+        assertTrue(rows.get(2).isNullAt(1));
+    }
+
+    @Test
+    public void testNestedComplexTypes() {
+        // Array of structs
+        spark.sql("CREATE TABLE ducklake.main.nested_complex (" +
+                "id INT, " +
+                "people ARRAY<STRUCT<name: STRING, age: INT>>)");
+
+        spark.sql("INSERT INTO ducklake.main.nested_complex VALUES " +
+                "(1, array(named_struct('name', 'alice', 'age', 30), " +
+                "named_struct('name', 'bob', 'age', 25)))");
+
+        Dataset<Row> result = spark.sql(
+                "SELECT people[0].name, people[0].age, people[1].name, people[1].age " +
+                "FROM ducklake.main.nested_complex");
+        Row row = result.collectAsList().get(0);
+        assertEquals("alice", row.getString(0));
+        assertEquals(30, row.getInt(1));
+        assertEquals("bob", row.getString(2));
+        assertEquals(25, row.getInt(3));
+    }
+
+    @Test
+    public void testMultipleRowsComplexTypes() {
+        spark.sql("CREATE TABLE ducklake.main.multi_complex (" +
+                "id INT, " +
+                "tags ARRAY<STRING>, " +
+                "meta MAP<STRING, INT>)");
+
+        // Insert multiple rows with varying sizes
+        spark.sql("INSERT INTO ducklake.main.multi_complex VALUES " +
+                "(1, array('a', 'b', 'c'), map('x', 1, 'y', 2)), " +
+                "(2, array('d'), map('z', 3)), " +
+                "(3, array(), map())");
+
+        Dataset<Row> result = spark.sql(
+                "SELECT id, size(tags), size(meta) " +
+                "FROM ducklake.main.multi_complex ORDER BY id");
+        List<Row> rows = result.collectAsList();
+        assertEquals(3, rows.size());
+
+        assertEquals(3, rows.get(0).getInt(1));
+        assertEquals(2, rows.get(0).getInt(2));
+
+        assertEquals(1, rows.get(1).getInt(1));
+        assertEquals(1, rows.get(1).getInt(2));
+
+        assertEquals(0, rows.get(2).getInt(1));
+        assertEquals(0, rows.get(2).getInt(2));
+    }
+
     // 4. Concurrent read access
     // ===============================================================
 


### PR DESCRIPTION
## Summary

Implement native Parquet encoding for complex types (ARRAY, STRUCT, MAP) in both writer and reader, replacing the string-serialization fallback.

## Changes

### Writer (`DuckLakeDataWriter`)
- **Schema conversion**: `ArrayType` → 3-level LIST, `StructType` → named group, `MapType` → MAP with key_value entries
- **Write path**: Handle `ArrayData`, `InternalRow` (struct), `MapData` with full recursive nesting support
- **Stats**: Skip min/max for complex types (count-only tracking)

### Reader (`DuckLakePartitionReader`)
- `ArrayType`: Read LIST groups into `GenericArrayData` with null element handling
- `StructType`: Read nested groups into `GenericInternalRow`
- `MapType`: Read key_value groups into `ArrayBasedMapData`
- Full recursive support for nested combinations (e.g. `ARRAY<STRUCT>`)

### Tests
- Un-`@Ignore` `testTypeRoundTripComplexTypes` (basic ARRAY/STRUCT/MAP round-trip)
- `testArrayWithNulls` — null elements, null arrays
- `testStructWithMultipleFields` — STRING/DOUBLE/BOOLEAN fields, null structs
- `testMapWithVariousTypes` — `MAP<STRING,DOUBLE>`, null maps
- `testNestedComplexTypes` — `ARRAY<STRUCT<name,age>>`
- `testMultipleRowsComplexTypes` — varying sizes, empty collections

All 124 tests pass (4 skipped are unrelated DuckDB version-alignment tests).