### PR TITLE
feat: MERGE INTO support via DuckLakeMerge builder API

### DIFF
--- a/src/main/java/io/ducklake/spark/maintenance/DuckLakeMerge.java
+++ b/src/main/java/io/ducklake/spark/maintenance/DuckLakeMerge.java
@@ -1,0 +1,1460 @@
+package io.ducklake.spark.maintenance;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+import io.ducklake.spark.util.DuckLakeTypeMapping;
+import io.ducklake.spark.writer.DuckLakeDeleteExecutor;
+import io.ducklake.spark.writer.DuckLakeRowFilterEvaluator;
+import io.ducklake.spark.writer.DuckLakeWriterCommitMessage;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.*;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.RecordReader;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.schema.*;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * MERGE INTO support for DuckLake tables via Spark.
+ *
+ * <p>Provides a builder-pattern API for executing MERGE operations (upserts)
+ * against DuckLake tables. This is analogous to the SQL MERGE INTO statement
+ * and supports matched updates, matched deletes, and not-matched inserts.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ *   DuckLakeMerge.into(spark, catalogPath, "target_table", "main")
+ *       .using(sourceDF, "source")
+ *       .on("target.id = source.id")
+ *       .whenMatched().updateAll()
+ *       .whenNotMatched().insertAll()
+ *       .execute();
+ * </pre>
+ *
+ * <p>Implementation uses copy-on-write semantics: matched rows that are updated
+ * produce delete files for old versions and new data files for updated versions.
+ * All changes are committed in a single atomic snapshot.</p>
+ */
+public class DuckLakeMerge {
+
+    private DuckLakeMerge() {} // utility class - use builder
+
+    /**
+     * Start building a MERGE INTO operation.
+     *
+     * @param spark       active SparkSession
+     * @param catalogPath path to the .ducklake catalog file
+     * @param tableName   name of the target table
+     * @param schemaName  schema (namespace) containing the table
+     * @return a MergeBuilder for fluent configuration
+     */
+    public static MergeBuilder into(SparkSession spark, String catalogPath,
+                                     String tableName, String schemaName) {
+        return new MergeBuilder(spark, catalogPath, tableName, schemaName);
+    }
+
+    // =================================================================
+    // Builder classes
+    // =================================================================
+
+    /**
+     * Fluent builder for configuring and executing a MERGE operation.
+     */
+    public static class MergeBuilder {
+        private final SparkSession spark;
+        private final String catalogPath;
+        private final String tableName;
+        private final String schemaName;
+        private String dataPathOption;
+
+        private Dataset<Row> sourceDF;
+        private String sourceAlias;
+        private String onCondition;
+
+        private final List<MatchedClause> matchedClauses = new ArrayList<>();
+        private final List<NotMatchedClause> notMatchedClauses = new ArrayList<>();
+
+        MergeBuilder(SparkSession spark, String catalogPath,
+                     String tableName, String schemaName) {
+            this.spark = spark;
+            this.catalogPath = catalogPath;
+            this.tableName = tableName;
+            this.schemaName = schemaName;
+        }
+
+        /**
+         * Override the data path (useful for testing).
+         * If not set, the data path is read from catalog metadata.
+         */
+        public MergeBuilder dataPath(String dataPath) {
+            this.dataPathOption = dataPath;
+            return this;
+        }
+
+        /**
+         * Specify the source DataFrame and its alias for the ON condition.
+         */
+        public MergeBuilder using(Dataset<Row> source, String alias) {
+            this.sourceDF = source;
+            this.sourceAlias = alias;
+            return this;
+        }
+
+        /**
+         * Specify the join condition between target and source.
+         * Supports equality conditions with optional AND:
+         * <pre>"target.id = source.id"</pre>
+         * <pre>"target.id = source.id AND target.region = source.region"</pre>
+         */
+        public MergeBuilder on(String condition) {
+            this.onCondition = condition;
+            return this;
+        }
+
+        /** Start defining what to do when a target row matches a source row. */
+        public WhenMatchedBuilder whenMatched() {
+            return new WhenMatchedBuilder(this, null);
+        }
+
+        /**
+         * Start defining what to do when a target row matches a source row
+         * AND the given additional condition is true.
+         *
+         * @param condition additional predicate, e.g. "source.value > 100"
+         */
+        public WhenMatchedBuilder whenMatched(String condition) {
+            return new WhenMatchedBuilder(this, condition);
+        }
+
+        /** Start defining what to do when a source row has no matching target row. */
+        public WhenNotMatchedBuilder whenNotMatched() {
+            return new WhenNotMatchedBuilder(this, null);
+        }
+
+        /**
+         * Start defining what to do when a source row has no matching target row
+         * AND the given additional condition is true.
+         */
+        public WhenNotMatchedBuilder whenNotMatched(String condition) {
+            return new WhenNotMatchedBuilder(this, condition);
+        }
+
+        /**
+         * Execute the MERGE operation. All changes are committed atomically
+         * in a single new snapshot.
+         */
+        public void execute() {
+            if (sourceDF == null) {
+                throw new IllegalStateException(
+                        "Source DataFrame not set. Call using() before execute().");
+            }
+            if (onCondition == null || onCondition.isEmpty()) {
+                throw new IllegalStateException(
+                        "ON condition not set. Call on() before execute().");
+            }
+            if (matchedClauses.isEmpty() && notMatchedClauses.isEmpty()) {
+                throw new IllegalStateException(
+                        "No WHEN clauses defined. Add at least one whenMatched() or whenNotMatched() clause.");
+            }
+
+            new MergeExecutor(this).run();
+        }
+    }
+
+    /** Builder for WHEN MATCHED actions. */
+    public static class WhenMatchedBuilder {
+        private final MergeBuilder parent;
+        private final String condition;
+
+        WhenMatchedBuilder(MergeBuilder parent, String condition) {
+            this.parent = parent;
+            this.condition = condition;
+        }
+
+        /** Update all target columns with values from the source row. */
+        public MergeBuilder updateAll() {
+            parent.matchedClauses.add(
+                    new MatchedClause(condition, MatchAction.UPDATE_ALL, null));
+            return parent;
+        }
+
+        /** Update specific target columns. Keys = target cols, values = source cols. */
+        public MergeBuilder update(Map<String, String> assignments) {
+            parent.matchedClauses.add(
+                    new MatchedClause(condition, MatchAction.UPDATE, assignments));
+            return parent;
+        }
+
+        /** Delete the matched target row. */
+        public MergeBuilder delete() {
+            parent.matchedClauses.add(
+                    new MatchedClause(condition, MatchAction.DELETE, null));
+            return parent;
+        }
+    }
+
+    /** Builder for WHEN NOT MATCHED actions. */
+    public static class WhenNotMatchedBuilder {
+        private final MergeBuilder parent;
+        private final String condition;
+
+        WhenNotMatchedBuilder(MergeBuilder parent, String condition) {
+            this.parent = parent;
+            this.condition = condition;
+        }
+
+        /** Insert all columns from the unmatched source row. */
+        public MergeBuilder insertAll() {
+            parent.notMatchedClauses.add(
+                    new NotMatchedClause(condition, InsertAction.INSERT_ALL, null));
+            return parent;
+        }
+
+        /** Insert specific columns. Keys = target cols, values = source cols. */
+        public MergeBuilder insert(Map<String, String> assignments) {
+            parent.notMatchedClauses.add(
+                    new NotMatchedClause(condition, InsertAction.INSERT, assignments));
+            return parent;
+        }
+    }
+
+    // =================================================================
+    // Internal data structures
+    // =================================================================
+
+    enum MatchAction { UPDATE_ALL, UPDATE, DELETE }
+    enum InsertAction { INSERT_ALL, INSERT }
+
+    static class MatchedClause {
+        final String condition;
+        final MatchAction action;
+        final Map<String, String> assignments;
+
+        MatchedClause(String condition, MatchAction action,
+                      Map<String, String> assignments) {
+            this.condition = condition;
+            this.action = action;
+            this.assignments = assignments;
+        }
+    }
+
+    static class NotMatchedClause {
+        final String condition;
+        final InsertAction action;
+        final Map<String, String> assignments;
+
+        NotMatchedClause(String condition, InsertAction action,
+                         Map<String, String> assignments) {
+            this.condition = condition;
+            this.action = action;
+            this.assignments = assignments;
+        }
+    }
+
+    /** Parsed join key pair: target column <-> source column. */
+    static class JoinKeyPair {
+        final String targetColumn;
+        final String sourceColumn;
+
+        JoinKeyPair(String targetColumn, String sourceColumn) {
+            this.targetColumn = targetColumn;
+            this.sourceColumn = sourceColumn;
+        }
+    }
+
+    // =================================================================
+    // Merge Executor
+    // =================================================================
+
+    private static class MergeExecutor {
+        private final MergeBuilder config;
+        private final List<JoinKeyPair> joinKeys;
+
+        MergeExecutor(MergeBuilder config) {
+            this.config = config;
+            this.joinKeys = parseOnCondition(config.onCondition, config.sourceAlias);
+        }
+
+        void run() {
+            List<Row> sourceRows = config.sourceDF.collectAsList();
+            if (sourceRows.isEmpty()) {
+                return; // Nothing to merge
+            }
+
+            StructType sourceSchema = config.sourceDF.schema();
+            Map<String, List<Integer>> sourceIndex =
+                    buildSourceIndex(sourceRows, sourceSchema);
+
+            try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(
+                    config.catalogPath, config.dataPathOption)) {
+                backend.beginTransaction();
+                try {
+                    executeMerge(backend, sourceRows, sourceSchema, sourceIndex);
+                    backend.commitTransaction();
+                } catch (Exception e) {
+                    try {
+                        backend.rollbackTransaction();
+                    } catch (SQLException ex) {
+                        e.addSuppressed(ex);
+                    }
+                    if (e instanceof RuntimeException) throw (RuntimeException) e;
+                    throw new RuntimeException("Failed to execute merge", e);
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException("Failed to execute merge", e);
+            }
+        }
+
+        private void executeMerge(DuckLakeMetadataBackend backend,
+                                   List<Row> sourceRows, StructType sourceSchema,
+                                   Map<String, List<Integer>> sourceIndex)
+                throws SQLException {
+            long currentSnap = backend.getCurrentSnapshotId();
+
+            TableInfo table = backend.getTable(
+                    config.tableName, config.schemaName, currentSnap);
+            if (table == null) {
+                throw new RuntimeException(
+                        "Table not found: " + config.schemaName + "." + config.tableName);
+            }
+
+            String dataPath = backend.getDataPath();
+            if (!dataPath.endsWith("/")) dataPath += "/";
+
+            List<DataFileInfo> dataFiles =
+                    backend.getDataFiles(table.tableId, currentSnap);
+            List<ColumnInfo> columns =
+                    backend.getColumns(table.tableId, currentSnap);
+
+            StructType targetSchema = DuckLakeTypeMapping.buildSchema(columns);
+
+            Map<Long, String> colIdToName = new HashMap<>();
+            for (ColumnInfo col : columns) {
+                colIdToName.put(col.columnId, col.name);
+            }
+
+            long[] columnIds = new long[columns.size()];
+            for (int i = 0; i < columns.size(); i++) {
+                columnIds[i] = columns.get(i).columnId;
+            }
+
+            CatalogState snapInfo = backend.getSnapshotInfo(currentSnap);
+            long nextFileId = snapInfo.nextFileId;
+
+            boolean[] sourceMatched = new boolean[sourceRows.size()];
+
+            List<DeleteFileResult> deleteResults = new ArrayList<>();
+            List<NewDataFileResult> newDataFiles = new ArrayList<>();
+
+            // --- Phase 1: scan target data files, match against source ---
+            for (DataFileInfo dataFile : dataFiles) {
+                String filePath = dataFile.pathIsRelative
+                        ? dataPath + dataFile.path : dataFile.path;
+
+                Set<Long> existingDeletes = loadExistingDeletes(
+                        backend, table.tableId, dataFile.dataFileId,
+                        currentSnap, dataPath);
+
+                Map<String, String> logicalToPhysical = buildLogicalToPhysical(
+                        backend, dataFile.mappingId, colIdToName);
+
+                ScanResult scanResult = scanAndMerge(
+                        filePath, targetSchema, sourceRows, sourceSchema,
+                        sourceIndex, existingDeletes, logicalToPhysical,
+                        columnIds, sourceMatched);
+
+                if (!scanResult.deletePositions.isEmpty()) {
+                    String deleteFileName = "delete_" + UUID.randomUUID() + ".parquet";
+                    String deleteRelPath = table.path + deleteFileName;
+                    String deleteAbsPath = dataPath + deleteRelPath;
+
+                    DuckLakeDeleteExecutor.writeDeleteFile(
+                            deleteAbsPath, scanResult.deletePositions);
+
+                    long deleteFileSize = new File(deleteAbsPath).length();
+                    deleteResults.add(new DeleteFileResult(
+                            dataFile.dataFileId, deleteRelPath,
+                            scanResult.deletePositions.size(), deleteFileSize));
+                }
+
+                if (!scanResult.updatedRows.isEmpty()) {
+                    String newFileName = "ducklake-" + UUID.randomUUID() + ".parquet";
+                    String newRelPath = table.path + newFileName;
+                    String newAbsPath = dataPath + newRelPath;
+
+                    writeDataRows(newAbsPath, targetSchema, columnIds,
+                            scanResult.updatedRows);
+
+                    long newFileSize = new File(newAbsPath).length();
+                    newDataFiles.add(new NewDataFileResult(
+                            newRelPath, scanResult.updatedRows.size(),
+                            newFileSize, scanResult.updateColumnStats));
+                }
+            }
+
+            // --- Phase 2: insert unmatched source rows ---
+            List<Object[]> insertRows = collectInsertRows(
+                    sourceRows, sourceSchema, sourceMatched,
+                    targetSchema, columns);
+
+            if (!insertRows.isEmpty()) {
+                String insertFileName = "ducklake-" + UUID.randomUUID() + ".parquet";
+                String insertRelPath = table.path + insertFileName;
+                String insertAbsPath = dataPath + insertRelPath;
+
+                List<DuckLakeWriterCommitMessage.ColumnStats> insertStats =
+                        writeDataRowsWithStats(
+                                insertAbsPath, targetSchema, columnIds, insertRows);
+
+                long insertFileSize = new File(insertAbsPath).length();
+                newDataFiles.add(new NewDataFileResult(
+                        insertRelPath, insertRows.size(),
+                        insertFileSize, insertStats));
+            }
+
+            // Nothing changed
+            if (deleteResults.isEmpty() && newDataFiles.isEmpty()) {
+                backend.rollbackTransaction();
+                return;
+            }
+
+            // --- Phase 3: commit all changes atomically ---
+            long newSnap = currentSnap + 1;
+            long totalNewFiles = deleteResults.size() + newDataFiles.size();
+            long newNextFileId = nextFileId + totalNewFiles;
+            backend.createSnapshot(newSnap, snapInfo.schemaVersion,
+                    snapInfo.nextCatalogId, newNextFileId);
+
+            long fileId = nextFileId;
+            long totalDeleteCount = 0;
+            for (DeleteFileResult result : deleteResults) {
+                backend.insertDeleteFile(fileId, table.tableId, newSnap,
+                        result.dataFileId, result.relativePath,
+                        result.deleteCount, result.fileSize);
+                totalDeleteCount += result.deleteCount;
+                fileId++;
+            }
+
+            TableStats stats = backend.getTableStats(table.tableId);
+            long rowIdStart = stats.nextRowId;
+            long totalNewRecords = 0;
+            long totalNewFileSize = 0;
+            int fileOrder = 0;
+
+            for (NewDataFileResult ndf : newDataFiles) {
+                backend.insertDataFile(fileId, table.tableId, newSnap,
+                        fileOrder, ndf.relativePath, ndf.recordCount,
+                        ndf.fileSize, rowIdStart);
+
+                for (DuckLakeWriterCommitMessage.ColumnStats cs : ndf.columnStats) {
+                    backend.insertColumnStats(fileId, table.tableId,
+                            cs.columnId, cs.valueCount, cs.nullCount,
+                            cs.minValue, cs.maxValue);
+                }
+
+                rowIdStart += ndf.recordCount;
+                totalNewRecords += ndf.recordCount;
+                totalNewFileSize += ndf.fileSize;
+                fileId++;
+                fileOrder++;
+            }
+
+            long newRecordCount =
+                    stats.recordCount - totalDeleteCount + totalNewRecords;
+            backend.updateTableStats(table.tableId, newRecordCount,
+                    rowIdStart, stats.fileSizeBytes + totalNewFileSize);
+
+            StringBuilder changeDesc = new StringBuilder();
+            if (totalDeleteCount > 0) {
+                changeDesc.append("deleted_from_table:")
+                          .append(table.tableId);
+            }
+            if (totalNewRecords > 0) {
+                if (changeDesc.length() > 0) changeDesc.append(",");
+                changeDesc.append("inserted_into_table:")
+                          .append(table.tableId);
+            }
+            backend.insertSnapshotChanges(newSnap, changeDesc.toString(),
+                    "ducklake-spark", "Spark merge");
+        }
+
+        // ---------------------------------------------------------------
+        // Scanning and matching
+        // ---------------------------------------------------------------
+
+        private ScanResult scanAndMerge(
+                String filePath, StructType targetSchema,
+                List<Row> sourceRows, StructType sourceSchema,
+                Map<String, List<Integer>> sourceIndex,
+                Set<Long> existingDeletes,
+                Map<String, String> logicalToPhysical,
+                long[] columnIds, boolean[] sourceMatched) {
+
+            List<Long> deletePositions = new ArrayList<>();
+            List<Object[]> updatedRows = new ArrayList<>();
+
+            StructField[] targetFields = targetSchema.fields();
+            Comparable<?>[] mins = new Comparable<?>[targetFields.length];
+            Comparable<?>[] maxs = new Comparable<?>[targetFields.length];
+            long[] nullCounts = new long[targetFields.length];
+            long[] valueCounts = new long[targetFields.length];
+
+            try (ParquetFileReader reader = ParquetFileReader.open(
+                    new Configuration(), new Path(filePath))) {
+                MessageType fileSchema =
+                        reader.getFooter().getFileMetaData().getSchema();
+
+                long rowPosition = 0;
+                PageReadStore pages;
+                while ((pages = reader.readNextRowGroup()) != null) {
+                    long rowCount = pages.getRowCount();
+                    ColumnIOFactory factory = new ColumnIOFactory();
+                    MessageColumnIO columnIO =
+                            factory.getColumnIO(fileSchema);
+                    RecordReader<Group> recordReader =
+                            columnIO.getRecordReader(
+                                    pages, new GroupRecordConverter(fileSchema));
+
+                    for (long i = 0; i < rowCount; i++) {
+                        Group group = recordReader.read();
+                        long pos = rowPosition++;
+
+                        if (existingDeletes.contains(pos)) {
+                            continue;
+                        }
+
+                        String joinKey = extractTargetJoinKey(
+                                group, fileSchema, logicalToPhysical,
+                                targetSchema);
+
+                        List<Integer> matchingSourceIndices =
+                                sourceIndex.get(joinKey);
+
+                        if (matchingSourceIndices != null
+                                && !matchingSourceIndices.isEmpty()) {
+                            // Cardinality check
+                            if (matchingSourceIndices.size() > 1) {
+                                throw new RuntimeException(
+                                    "MERGE validation failed: multiple source "
+                                    + "rows matched the same target row for "
+                                    + "join key [" + joinKey + "]. MERGE "
+                                    + "requires at most one source row per "
+                                    + "target row.");
+                            }
+
+                            int srcIdx = matchingSourceIndices.get(0);
+                            Row sourceRow = sourceRows.get(srcIdx);
+
+                            for (MatchedClause clause :
+                                    config.matchedClauses) {
+                                if (clause.condition != null
+                                        && !evaluateCondition(
+                                            clause.condition,
+                                            group, fileSchema,
+                                            logicalToPhysical,
+                                            targetSchema,
+                                            sourceRow, sourceSchema)) {
+                                    continue;
+                                }
+
+                                sourceMatched[srcIdx] = true;
+
+                                switch (clause.action) {
+                                    case DELETE:
+                                        deletePositions.add(pos);
+                                        break;
+
+                                    case UPDATE_ALL:
+                                        deletePositions.add(pos);
+                                        Object[] uRow = buildUpdatedRowAll(
+                                                group, fileSchema,
+                                                logicalToPhysical,
+                                                targetSchema,
+                                                sourceRow, sourceSchema);
+                                        for (int c = 0;
+                                                c < targetFields.length;
+                                                c++) {
+                                            trackStats(uRow[c], c,
+                                                    mins, maxs,
+                                                    nullCounts, valueCounts);
+                                        }
+                                        updatedRows.add(uRow);
+                                        break;
+
+                                    case UPDATE:
+                                        deletePositions.add(pos);
+                                        Object[] pRow =
+                                                buildUpdatedRowPartial(
+                                                    group, fileSchema,
+                                                    logicalToPhysical,
+                                                    targetSchema,
+                                                    sourceRow, sourceSchema,
+                                                    clause.assignments);
+                                        for (int c = 0;
+                                                c < targetFields.length;
+                                                c++) {
+                                            trackStats(pRow[c], c,
+                                                    mins, maxs,
+                                                    nullCounts, valueCounts);
+                                        }
+                                        updatedRows.add(pRow);
+                                        break;
+                                }
+                                break; // First matching clause wins
+                            }
+                        }
+                    }
+                }
+            } catch (RuntimeException re) {
+                throw re;
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        "Failed to scan file for merge: " + filePath, e);
+            }
+
+            List<DuckLakeWriterCommitMessage.ColumnStats> colStats =
+                    new ArrayList<>();
+            for (int c = 0; c < targetFields.length; c++) {
+                String minStr = mins[c] != null ? mins[c].toString() : null;
+                String maxStr = maxs[c] != null ? maxs[c].toString() : null;
+                colStats.add(new DuckLakeWriterCommitMessage.ColumnStats(
+                        columnIds[c], minStr, maxStr,
+                        nullCounts[c], valueCounts[c]));
+            }
+
+            return new ScanResult(deletePositions, updatedRows, colStats);
+        }
+
+        // ---------------------------------------------------------------
+        // Join key extraction and indexing
+        // ---------------------------------------------------------------
+
+        private Map<String, List<Integer>> buildSourceIndex(
+                List<Row> sourceRows, StructType sourceSchema) {
+            Map<String, List<Integer>> index = new HashMap<>();
+            for (int i = 0; i < sourceRows.size(); i++) {
+                String key = extractSourceJoinKey(
+                        sourceRows.get(i), sourceSchema);
+                index.computeIfAbsent(key, k -> new ArrayList<>()).add(i);
+            }
+            return index;
+        }
+
+        private String extractSourceJoinKey(Row row, StructType schema) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < joinKeys.size(); i++) {
+                if (i > 0) sb.append("|");
+                String srcCol = joinKeys.get(i).sourceColumn;
+                int fieldIdx = schema.fieldIndex(srcCol);
+                Object val = row.isNullAt(fieldIdx)
+                        ? "NULL" : row.get(fieldIdx);
+                sb.append(val);
+            }
+            return sb.toString();
+        }
+
+        private String extractTargetJoinKey(
+                Group group, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                StructType targetSchema) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < joinKeys.size(); i++) {
+                if (i > 0) sb.append("|");
+                String tgtCol = joinKeys.get(i).targetColumn;
+                Object val = readGroupValue(group, fileSchema,
+                        logicalToPhysical, tgtCol,
+                        findDataType(targetSchema, tgtCol));
+                sb.append(val == null ? "NULL" : val);
+            }
+            return sb.toString();
+        }
+
+        // ---------------------------------------------------------------
+        // Row building
+        // ---------------------------------------------------------------
+
+        private Object[] buildUpdatedRowAll(
+                Group group, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                StructType targetSchema,
+                Row sourceRow, StructType sourceSchema) {
+            StructField[] fields = targetSchema.fields();
+            Object[] row = new Object[fields.length];
+
+            for (int i = 0; i < fields.length; i++) {
+                String colName = fields[i].name();
+                int srcIdx = findFieldIndex(sourceSchema, colName);
+                if (srcIdx >= 0 && !sourceRow.isNullAt(srcIdx)) {
+                    row[i] = sourceRow.get(srcIdx);
+                } else if (srcIdx >= 0) {
+                    row[i] = null;
+                } else {
+                    row[i] = readGroupValue(group, fileSchema,
+                            logicalToPhysical, colName,
+                            fields[i].dataType());
+                }
+            }
+            return row;
+        }
+
+        private Object[] buildUpdatedRowPartial(
+                Group group, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                StructType targetSchema,
+                Row sourceRow, StructType sourceSchema,
+                Map<String, String> assignments) {
+            StructField[] fields = targetSchema.fields();
+            Object[] row = new Object[fields.length];
+
+            for (int i = 0; i < fields.length; i++) {
+                String colName = fields[i].name();
+                if (assignments.containsKey(colName)) {
+                    String srcCol = assignments.get(colName);
+                    int srcIdx = sourceSchema.fieldIndex(srcCol);
+                    row[i] = sourceRow.isNullAt(srcIdx)
+                            ? null : sourceRow.get(srcIdx);
+                } else {
+                    row[i] = readGroupValue(group, fileSchema,
+                            logicalToPhysical, colName,
+                            fields[i].dataType());
+                }
+            }
+            return row;
+        }
+
+        private List<Object[]> collectInsertRows(
+                List<Row> sourceRows, StructType sourceSchema,
+                boolean[] sourceMatched,
+                StructType targetSchema,
+                List<ColumnInfo> columns) {
+            List<Object[]> insertRows = new ArrayList<>();
+
+            for (NotMatchedClause clause : config.notMatchedClauses) {
+                for (int i = 0; i < sourceRows.size(); i++) {
+                    if (sourceMatched[i]) continue;
+
+                    Row sourceRow = sourceRows.get(i);
+
+                    if (clause.condition != null
+                            && !evaluateSourceCondition(
+                                clause.condition,
+                                sourceRow, sourceSchema)) {
+                        continue;
+                    }
+
+                    StructField[] targetFields = targetSchema.fields();
+                    Object[] row = new Object[targetFields.length];
+
+                    if (clause.action == InsertAction.INSERT_ALL) {
+                        for (int c = 0; c < targetFields.length; c++) {
+                            String colName = targetFields[c].name();
+                            int srcIdx = findFieldIndex(
+                                    sourceSchema, colName);
+                            if (srcIdx >= 0
+                                    && !sourceRow.isNullAt(srcIdx)) {
+                                row[c] = sourceRow.get(srcIdx);
+                            } else {
+                                row[c] = null;
+                            }
+                        }
+                    } else {
+                        for (int c = 0; c < targetFields.length; c++) {
+                            String colName = targetFields[c].name();
+                            if (clause.assignments.containsKey(colName)) {
+                                String srcCol =
+                                        clause.assignments.get(colName);
+                                int srcIdx =
+                                        sourceSchema.fieldIndex(srcCol);
+                                row[c] = sourceRow.isNullAt(srcIdx)
+                                        ? null : sourceRow.get(srcIdx);
+                            } else {
+                                row[c] = null;
+                            }
+                        }
+                    }
+
+                    insertRows.add(row);
+                    sourceMatched[i] = true;
+                }
+            }
+
+            return insertRows;
+        }
+
+        // ---------------------------------------------------------------
+        // Condition evaluation
+        // ---------------------------------------------------------------
+
+        private boolean evaluateCondition(
+                String condition,
+                Group targetGroup, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                StructType targetSchema,
+                Row sourceRow, StructType sourceSchema) {
+            String[] parts = condition.split("(?i)\\s+AND\\s+");
+            for (String part : parts) {
+                if (!evaluateSingleCondition(part.trim(),
+                        targetGroup, fileSchema, logicalToPhysical,
+                        targetSchema, sourceRow, sourceSchema)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private boolean evaluateSingleCondition(
+                String expr,
+                Group targetGroup, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                StructType targetSchema,
+                Row sourceRow, StructType sourceSchema) {
+            String[] ops = {"!=", ">=", "<=", ">", "<", "="};
+            for (String op : ops) {
+                int idx = findOperator(expr, op);
+                if (idx >= 0) {
+                    String lhs = expr.substring(0, idx).trim();
+                    String rhs = expr.substring(
+                            idx + op.length()).trim();
+
+                    Object lhsVal = resolveValue(lhs,
+                            targetGroup, fileSchema,
+                            logicalToPhysical, targetSchema,
+                            sourceRow, sourceSchema);
+                    Object rhsVal = resolveValue(rhs,
+                            targetGroup, fileSchema,
+                            logicalToPhysical, targetSchema,
+                            sourceRow, sourceSchema);
+
+                    int cmp = DuckLakeRowFilterEvaluator
+                            .compareValues(lhsVal, rhsVal);
+
+                    switch (op) {
+                        case "=":  return cmp == 0;
+                        case "!=": return cmp != 0;
+                        case ">":  return cmp > 0;
+                        case ">=": return cmp >= 0;
+                        case "<":  return cmp < 0;
+                        case "<=": return cmp <= 0;
+                    }
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Find operator position, avoiding confusion between
+         * >, >=, <, <=, =, !=.
+         */
+        private int findOperator(String expr, String op) {
+            int idx = expr.indexOf(op);
+            if (idx < 0) return -1;
+
+            // For single-char ops, make sure they're not part of
+            // a multi-char op
+            if (op.equals("=")) {
+                // Make sure it's not != or >= or <=
+                if (idx > 0) {
+                    char before = expr.charAt(idx - 1);
+                    if (before == '!' || before == '>'
+                            || before == '<') {
+                        return -1;
+                    }
+                }
+            } else if (op.equals(">")) {
+                // Make sure it's not >=
+                if (idx + 1 < expr.length()
+                        && expr.charAt(idx + 1) == '=') {
+                    return -1;
+                }
+            } else if (op.equals("<")) {
+                // Make sure it's not <=
+                if (idx + 1 < expr.length()
+                        && expr.charAt(idx + 1) == '=') {
+                    return -1;
+                }
+            }
+            return idx;
+        }
+
+        private Object resolveValue(
+                String token,
+                Group targetGroup, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                StructType targetSchema,
+                Row sourceRow, StructType sourceSchema) {
+            // Number literal
+            try {
+                if (token.contains(".")) {
+                    return Double.parseDouble(token);
+                }
+                return Long.parseLong(token);
+            } catch (NumberFormatException ignored) {}
+
+            // Quoted string literal
+            if ((token.startsWith("'") && token.endsWith("'"))
+                    || (token.startsWith("\"")
+                        && token.endsWith("\""))) {
+                return token.substring(1, token.length() - 1);
+            }
+
+            // Column reference with alias
+            if (token.contains(".")) {
+                String[] parts = token.split("\\.", 2);
+                String alias = parts[0].trim();
+                String col = parts[1].trim();
+
+                if (alias.equalsIgnoreCase(config.sourceAlias)) {
+                    int srcIdx = findFieldIndex(sourceSchema, col);
+                    if (srcIdx >= 0) {
+                        return sourceRow.isNullAt(srcIdx)
+                                ? null : sourceRow.get(srcIdx);
+                    }
+                } else {
+                    return readGroupValue(targetGroup, fileSchema,
+                            logicalToPhysical, col,
+                            findDataType(targetSchema, col));
+                }
+            }
+
+            // Unqualified: try source first, then target
+            int srcIdx = findFieldIndex(sourceSchema, token);
+            if (srcIdx >= 0) {
+                return sourceRow.isNullAt(srcIdx)
+                        ? null : sourceRow.get(srcIdx);
+            }
+            return readGroupValue(targetGroup, fileSchema,
+                    logicalToPhysical, token,
+                    findDataType(targetSchema, token));
+        }
+
+        private boolean evaluateSourceCondition(
+                String condition, Row sourceRow,
+                StructType sourceSchema) {
+            String[] parts = condition.split("(?i)\\s+AND\\s+");
+            for (String part : parts) {
+                if (!evaluateSingleSourceCondition(
+                        part.trim(), sourceRow, sourceSchema)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private boolean evaluateSingleSourceCondition(
+                String expr, Row sourceRow,
+                StructType sourceSchema) {
+            String[] ops = {"!=", ">=", "<=", ">", "<", "="};
+            for (String op : ops) {
+                int idx = findOperator(expr, op);
+                if (idx >= 0) {
+                    String lhs = expr.substring(0, idx).trim();
+                    String rhs = expr.substring(
+                            idx + op.length()).trim();
+
+                    Object lhsVal = resolveSourceValue(
+                            lhs, sourceRow, sourceSchema);
+                    Object rhsVal = resolveSourceValue(
+                            rhs, sourceRow, sourceSchema);
+
+                    int cmp = DuckLakeRowFilterEvaluator
+                            .compareValues(lhsVal, rhsVal);
+
+                    switch (op) {
+                        case "=":  return cmp == 0;
+                        case "!=": return cmp != 0;
+                        case ">":  return cmp > 0;
+                        case ">=": return cmp >= 0;
+                        case "<":  return cmp < 0;
+                        case "<=": return cmp <= 0;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private Object resolveSourceValue(
+                String token, Row sourceRow,
+                StructType sourceSchema) {
+            try {
+                if (token.contains(".")) {
+                    return Double.parseDouble(token);
+                }
+                return Long.parseLong(token);
+            } catch (NumberFormatException ignored) {}
+
+            if ((token.startsWith("'") && token.endsWith("'"))
+                    || (token.startsWith("\"")
+                        && token.endsWith("\""))) {
+                return token.substring(1, token.length() - 1);
+            }
+
+            String col = token.contains(".")
+                    ? token.split("\\.", 2)[1].trim() : token;
+            int srcIdx = findFieldIndex(sourceSchema, col);
+            if (srcIdx >= 0) {
+                return sourceRow.isNullAt(srcIdx)
+                        ? null : sourceRow.get(srcIdx);
+            }
+            return null;
+        }
+
+        // ---------------------------------------------------------------
+        // Parquet reading helpers
+        // ---------------------------------------------------------------
+
+        private Object readGroupValue(
+                Group group, MessageType fileSchema,
+                Map<String, String> logicalToPhysical,
+                String logicalName, DataType sparkType) {
+            if (sparkType == null) return null;
+            String physicalName = logicalToPhysical.getOrDefault(
+                    logicalName, logicalName);
+            int fieldIndex;
+            try {
+                fieldIndex = fileSchema.getFieldIndex(physicalName);
+            } catch (Exception e) {
+                return null;
+            }
+            if (group.getFieldRepetitionCount(fieldIndex) == 0) {
+                return null;
+            }
+            try {
+                if (sparkType instanceof BooleanType) {
+                    return group.getBoolean(fieldIndex, 0);
+                } else if (sparkType instanceof ByteType) {
+                    return (byte) group.getInteger(fieldIndex, 0);
+                } else if (sparkType instanceof ShortType) {
+                    return (short) group.getInteger(fieldIndex, 0);
+                } else if (sparkType instanceof IntegerType) {
+                    return group.getInteger(fieldIndex, 0);
+                } else if (sparkType instanceof LongType) {
+                    return group.getLong(fieldIndex, 0);
+                } else if (sparkType instanceof FloatType) {
+                    return group.getFloat(fieldIndex, 0);
+                } else if (sparkType instanceof DoubleType) {
+                    return group.getDouble(fieldIndex, 0);
+                } else if (sparkType instanceof StringType) {
+                    return group.getString(fieldIndex, 0);
+                } else {
+                    return group.getValueToString(fieldIndex, 0);
+                }
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // File writing
+        // ---------------------------------------------------------------
+
+        private void writeDataRows(String absolutePath,
+                                    StructType sparkSchema,
+                                    long[] columnIds,
+                                    List<Object[]> rows) {
+            writeDataRowsWithStats(
+                    absolutePath, sparkSchema, columnIds, rows);
+        }
+
+        private List<DuckLakeWriterCommitMessage.ColumnStats>
+                writeDataRowsWithStats(
+                    String absolutePath, StructType sparkSchema,
+                    long[] columnIds, List<Object[]> rows) {
+            MessageType parquetSchema =
+                    buildParquetSchema(sparkSchema, columnIds);
+            SimpleGroupFactory groupFactory =
+                    new SimpleGroupFactory(parquetSchema);
+
+            StructField[] fields = sparkSchema.fields();
+            Comparable<?>[] mins =
+                    new Comparable<?>[fields.length];
+            Comparable<?>[] maxs =
+                    new Comparable<?>[fields.length];
+            long[] nullCounts = new long[fields.length];
+            long[] valueCnts = new long[fields.length];
+
+            File parentDir = new File(absolutePath).getParentFile();
+            if (parentDir != null && !parentDir.exists()) {
+                parentDir.mkdirs();
+            }
+
+            try (ParquetWriter<Group> writer =
+                    ExampleParquetWriter
+                            .builder(new Path(absolutePath))
+                            .withType(parquetSchema)
+                            .withConf(new Configuration())
+                            .withWriteMode(
+                                    ParquetFileWriter.Mode.CREATE)
+                            .build()) {
+                for (Object[] row : rows) {
+                    Group group = groupFactory.newGroup();
+                    for (int i = 0; i < fields.length; i++) {
+                        if (row[i] != null) {
+                            writeField(group, i, row[i],
+                                    fields[i].dataType());
+                        }
+                        trackStats(row[i], i,
+                                mins, maxs,
+                                nullCounts, valueCnts);
+                    }
+                    writer.write(group);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        "Failed to write data file: "
+                                + absolutePath, e);
+            }
+
+            List<DuckLakeWriterCommitMessage.ColumnStats> colStats =
+                    new ArrayList<>();
+            for (int i = 0; i < fields.length; i++) {
+                String minStr = mins[i] != null
+                        ? mins[i].toString() : null;
+                String maxStr = maxs[i] != null
+                        ? maxs[i].toString() : null;
+                colStats.add(
+                        new DuckLakeWriterCommitMessage.ColumnStats(
+                                columnIds[i], minStr, maxStr,
+                                nullCounts[i], valueCnts[i]));
+            }
+            return colStats;
+        }
+
+        private void writeField(Group group, int fieldIndex,
+                                 Object value, DataType type) {
+            if (type instanceof BooleanType) {
+                group.add(fieldIndex, (Boolean) value);
+            } else if (type instanceof ByteType) {
+                group.add(fieldIndex, (int) ((Byte) value));
+            } else if (type instanceof ShortType) {
+                group.add(fieldIndex, (int) ((Short) value));
+            } else if (type instanceof IntegerType) {
+                group.add(fieldIndex, (Integer) value);
+            } else if (type instanceof LongType) {
+                group.add(fieldIndex, (Long) value);
+            } else if (type instanceof FloatType) {
+                group.add(fieldIndex, (Float) value);
+            } else if (type instanceof DoubleType) {
+                group.add(fieldIndex, (Double) value);
+            } else if (type instanceof StringType) {
+                group.add(fieldIndex, value.toString());
+            } else {
+                group.add(fieldIndex, value.toString());
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Stats tracking
+        // ---------------------------------------------------------------
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private void trackStats(Object value, int colIdx,
+                                 Comparable<?>[] mins,
+                                 Comparable<?>[] maxs,
+                                 long[] nullCounts,
+                                 long[] valueCounts) {
+            if (value == null) {
+                nullCounts[colIdx]++;
+                return;
+            }
+            valueCounts[colIdx]++;
+            if (value instanceof Comparable) {
+                Comparable comp = (Comparable) value;
+                if (mins[colIdx] == null
+                        || comp.compareTo(mins[colIdx]) < 0) {
+                    mins[colIdx] = comp;
+                }
+                if (maxs[colIdx] == null
+                        || comp.compareTo(maxs[colIdx]) > 0) {
+                    maxs[colIdx] = comp;
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Schema helpers
+        // ---------------------------------------------------------------
+
+        private static MessageType buildParquetSchema(
+                StructType sparkSchema, long[] columnIds) {
+            Types.MessageTypeBuilder builder =
+                    Types.buildMessage();
+            for (int i = 0; i < sparkSchema.fields().length; i++) {
+                StructField field = sparkSchema.fields()[i];
+                int fieldId = (int) columnIds[i];
+                builder.addField(sparkTypeToParquetType(
+                        field.name(), field.dataType(),
+                        field.nullable(), fieldId));
+            }
+            return builder.named("spark_schema");
+        }
+
+        private static org.apache.parquet.schema.Type
+                sparkTypeToParquetType(
+                    String name, DataType type,
+                    boolean nullable, int fieldId) {
+            PrimitiveType.PrimitiveTypeName typeName;
+            LogicalTypeAnnotation logicalType = null;
+
+            if (type instanceof BooleanType) {
+                typeName = PrimitiveType.PrimitiveTypeName.BOOLEAN;
+            } else if (type instanceof ByteType
+                    || type instanceof ShortType
+                    || type instanceof IntegerType) {
+                typeName = PrimitiveType.PrimitiveTypeName.INT32;
+            } else if (type instanceof LongType) {
+                typeName = PrimitiveType.PrimitiveTypeName.INT64;
+            } else if (type instanceof FloatType) {
+                typeName = PrimitiveType.PrimitiveTypeName.FLOAT;
+            } else if (type instanceof DoubleType) {
+                typeName = PrimitiveType.PrimitiveTypeName.DOUBLE;
+            } else {
+                typeName = PrimitiveType.PrimitiveTypeName.BINARY;
+                logicalType = LogicalTypeAnnotation.stringType();
+            }
+
+            if (logicalType != null) {
+                return nullable
+                    ? Types.optional(typeName).as(logicalType)
+                            .id(fieldId).named(name)
+                    : Types.required(typeName).as(logicalType)
+                            .id(fieldId).named(name);
+            } else {
+                return nullable
+                    ? Types.optional(typeName)
+                            .id(fieldId).named(name)
+                    : Types.required(typeName)
+                            .id(fieldId).named(name);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Common helpers
+        // ---------------------------------------------------------------
+
+        private Set<Long> loadExistingDeletes(
+                DuckLakeMetadataBackend backend, long tableId,
+                long dataFileId, long snapshotId,
+                String dataPath) throws SQLException {
+            Set<Long> deleted = new HashSet<>();
+            List<DeleteFileInfo> deleteFiles =
+                    backend.getDeleteFiles(
+                            tableId, dataFileId, snapshotId);
+            for (DeleteFileInfo df : deleteFiles) {
+                String path = df.pathIsRelative
+                        ? dataPath + df.path : df.path;
+                try (ParquetFileReader reader =
+                        ParquetFileReader.open(
+                                new Configuration(),
+                                new Path(path))) {
+                    MessageType schema = reader.getFooter()
+                            .getFileMetaData().getSchema();
+                    PageReadStore pages;
+                    while ((pages = reader.readNextRowGroup())
+                            != null) {
+                        ColumnIOFactory factory =
+                                new ColumnIOFactory();
+                        MessageColumnIO columnIO =
+                                factory.getColumnIO(schema);
+                        RecordReader<Group> recordReader =
+                                columnIO.getRecordReader(pages,
+                                        new GroupRecordConverter(
+                                                schema));
+                        for (long i = 0;
+                                i < pages.getRowCount(); i++) {
+                            Group group = recordReader.read();
+                            int fieldIdx =
+                                    schema.getFieldIndex("row_id");
+                            deleted.add(
+                                    group.getLong(fieldIdx, 0));
+                        }
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            "Failed to read delete file: "
+                                    + path, e);
+                }
+            }
+            return deleted;
+        }
+
+        private Map<String, String> buildLogicalToPhysical(
+                DuckLakeMetadataBackend backend,
+                long mappingId,
+                Map<Long, String> colIdToName)
+                throws SQLException {
+            Map<String, String> logicalToPhysical =
+                    new HashMap<>();
+            if (mappingId >= 0) {
+                Map<Long, String> nameMapping =
+                        backend.getNameMapping(mappingId);
+                for (Map.Entry<Long, String> entry :
+                        nameMapping.entrySet()) {
+                    long fieldId = entry.getKey();
+                    String physicalName = entry.getValue();
+                    String logicalName =
+                            colIdToName.get(fieldId);
+                    if (logicalName != null
+                            && !physicalName.equals(
+                                    logicalName)) {
+                        logicalToPhysical.put(
+                                logicalName, physicalName);
+                    }
+                }
+            }
+            return logicalToPhysical;
+        }
+
+        private static int findFieldIndex(
+                StructType schema, String name) {
+            try {
+                return schema.fieldIndex(name);
+            } catch (Exception e) {
+                return -1;
+            }
+        }
+
+        private static DataType findDataType(
+                StructType schema, String name) {
+            int idx = findFieldIndex(schema, name);
+            return idx >= 0
+                    ? schema.fields()[idx].dataType() : null;
+        }
+    }
+
+    // =================================================================
+    // ON condition parser
+    // =================================================================
+
+    static List<JoinKeyPair> parseOnCondition(
+            String condition, String sourceAlias) {
+        List<JoinKeyPair> keys = new ArrayList<>();
+
+        String[] parts = condition.split("(?i)\\s+AND\\s+");
+        for (String part : parts) {
+            part = part.trim();
+            int eqIdx = part.indexOf('=');
+            if (eqIdx < 0) {
+                throw new IllegalArgumentException(
+                        "Invalid ON condition: expected equality "
+                        + "expression, got: " + part);
+            }
+
+            if (eqIdx > 0 && part.charAt(eqIdx - 1) == '!') {
+                throw new IllegalArgumentException(
+                        "Invalid ON condition: != not supported "
+                        + "in join condition, got: " + part);
+            }
+
+            String lhs = part.substring(0, eqIdx).trim();
+            String rhs = part.substring(eqIdx + 1).trim();
+
+            String[] lhsParts = lhs.split("\\.", 2);
+            String[] rhsParts = rhs.split("\\.", 2);
+
+            String lhsAlias = lhsParts.length == 2
+                    ? lhsParts[0].trim() : null;
+            String lhsCol = lhsParts.length == 2
+                    ? lhsParts[1].trim() : lhsParts[0].trim();
+            String rhsAlias = rhsParts.length == 2
+                    ? rhsParts[0].trim() : null;
+            String rhsCol = rhsParts.length == 2
+                    ? rhsParts[1].trim() : rhsParts[0].trim();
+
+            String targetCol, sourceCol;
+
+            if (lhsAlias != null
+                    && lhsAlias.equalsIgnoreCase(sourceAlias)) {
+                sourceCol = lhsCol;
+                targetCol = rhsCol;
+            } else if (rhsAlias != null
+                    && rhsAlias.equalsIgnoreCase(sourceAlias)) {
+                sourceCol = rhsCol;
+                targetCol = lhsCol;
+            } else {
+                targetCol = lhsCol;
+                sourceCol = rhsCol;
+            }
+
+            keys.add(new JoinKeyPair(targetCol, sourceCol));
+        }
+
+        if (keys.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "ON condition produced no join keys: "
+                            + condition);
+        }
+
+        return keys;
+    }
+
+    // =================================================================
+    // Result data classes
+    // =================================================================
+
+    private static class DeleteFileResult {
+        final long dataFileId;
+        final String relativePath;
+        final long deleteCount;
+        final long fileSize;
+
+        DeleteFileResult(long dataFileId, String relativePath,
+                         long deleteCount, long fileSize) {
+            this.dataFileId = dataFileId;
+            this.relativePath = relativePath;
+            this.deleteCount = deleteCount;
+            this.fileSize = fileSize;
+        }
+    }
+
+    private static class NewDataFileResult {
+        final String relativePath;
+        final long recordCount;
+        final long fileSize;
+        final List<DuckLakeWriterCommitMessage.ColumnStats>
+                columnStats;
+
+        NewDataFileResult(
+                String relativePath, long recordCount,
+                long fileSize,
+                List<DuckLakeWriterCommitMessage.ColumnStats>
+                        columnStats) {
+            this.relativePath = relativePath;
+            this.recordCount = recordCount;
+            this.fileSize = fileSize;
+            this.columnStats = columnStats;
+        }
+    }
+
+    private static class ScanResult {
+        final List<Long> deletePositions;
+        final List<Object[]> updatedRows;
+        final List<DuckLakeWriterCommitMessage.ColumnStats>
+                updateColumnStats;
+
+        ScanResult(List<Long> deletePositions,
+                   List<Object[]> updatedRows,
+                   List<DuckLakeWriterCommitMessage.ColumnStats>
+                           updateColumnStats) {
+            this.deletePositions = deletePositions;
+            this.updatedRows = updatedRows;
+            this.updateColumnStats = updateColumnStats;
+        }
+    }
+}

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeDeleteExecutor.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeDeleteExecutor.java
@@ -202,7 +202,7 @@ public class DuckLakeDeleteExecutor {
     /**
      * Write a delete file (Parquet) with a single {@code row_id} column.
      */
-    static void writeDeleteFile(String absolutePath, List<Long> rowIds) {
+    public static void writeDeleteFile(String absolutePath, List<Long> rowIds) {
         MessageType deleteSchema = Types.buildMessage()
                 .required(PrimitiveType.PrimitiveTypeName.INT64).named("row_id")
                 .named("delete_file");

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeRowFilterEvaluator.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeRowFilterEvaluator.java
@@ -213,7 +213,7 @@ public class DuckLakeRowFilterEvaluator {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    static int compareValues(Object rowValue, Object filterValue) {
+    public static int compareValues(Object rowValue, Object filterValue) {
         if (rowValue == null && filterValue == null) return 0;
         if (rowValue == null) return -1;
         if (filterValue == null) return 1;

--- a/src/test/java/io/ducklake/spark/DuckLakeMergeTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeMergeTest.java
@@ -1,0 +1,746 @@
+package io.ducklake.spark;
+
+import io.ducklake.spark.maintenance.DuckLakeMerge;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.junit.*;
+
+import java.io.File;
+import java.nio.file.*;
+import java.sql.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for DuckLake MERGE INTO operations.
+ */
+public class DuckLakeMergeTest {
+
+    private static SparkSession spark;
+    private static String tempDir;
+    private static String catalogPath;
+    private static String dataPath;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        tempDir = Files.createTempDirectory("ducklake-merge-test-").toString();
+        dataPath = tempDir + "/data/";
+        new File(dataPath).mkdirs();
+        catalogPath = tempDir + "/test.ducklake";
+        createMinimalCatalog(catalogPath, dataPath);
+
+        Thread.currentThread().setContextClassLoader(
+                DuckLakeMergeTest.class.getClassLoader());
+
+        spark = SparkSession.builder()
+                .master("local[2]")
+                .appName("DuckLakeMergeTest")
+                .config("spark.ui.enabled", "false")
+                .config("spark.driver.host", "localhost")
+                .config("spark.sql.catalog.ducklake",
+                        "io.ducklake.spark.catalog.DuckLakeCatalog")
+                .config("spark.sql.catalog.ducklake.catalog",
+                        catalogPath)
+                .config("spark.sql.catalog.ducklake.data_path",
+                        dataPath)
+                .getOrCreate();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (spark != null) {
+            spark.stop();
+            spark = null;
+        }
+        if (tempDir != null) {
+            deleteRecursive(new File(tempDir));
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Helper: create and populate target table
+    // ---------------------------------------------------------------
+
+    private void createAndPopulateTable(String tableName, int numRows) {
+        spark.sql("CREATE TABLE IF NOT EXISTS ducklake.main."
+                + tableName
+                + " (id INT, name STRING, value DOUBLE)");
+
+        StringBuilder values = new StringBuilder();
+        for (int i = 1; i <= numRows; i++) {
+            if (i > 1) values.append(", ");
+            values.append("(").append(i)
+                  .append(", 'name_").append(i)
+                  .append("', ").append(i * 10.0)
+                  .append(")");
+        }
+        spark.sql("INSERT INTO ducklake.main." + tableName
+                + " VALUES " + values);
+    }
+
+    /**
+     * Build a source DataFrame from rows of (id, name, value).
+     */
+    private Dataset<Row> createSourceDF(Object[]... rows) {
+        StructType schema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+
+        List<Row> rowList = new ArrayList<>();
+        for (Object[] r : rows) {
+            rowList.add(RowFactory.create(r));
+        }
+        return spark.createDataFrame(rowList, schema);
+    }
+
+    // ---------------------------------------------------------------
+    // Basic upsert: update matched, insert unmatched
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testBasicUpsert() {
+        createAndPopulateTable("merge_upsert", 5);
+
+        // Source: id=3 exists (update), id=10 is new (insert)
+        Dataset<Row> source = createSourceDF(
+                new Object[]{3, "updated_3", 300.0},
+                new Object[]{10, "new_10", 100.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_upsert", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_upsert ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        // 5 original + 1 new = 6 total (id=3 updated, not duplicated)
+        assertEquals(6, rows.size());
+
+        // Verify id=3 was updated
+        Row row3 = rows.get(2);
+        assertEquals(3, row3.getInt(0));
+        assertEquals("updated_3", row3.getString(1));
+        assertEquals(300.0, row3.getDouble(2), 0.001);
+
+        // Verify id=10 was inserted
+        Row row10 = rows.get(5);
+        assertEquals(10, row10.getInt(0));
+        assertEquals("new_10", row10.getString(1));
+        assertEquals(100.0, row10.getDouble(2), 0.001);
+
+        // Verify other rows unchanged
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals("name_1", rows.get(0).getString(1));
+    }
+
+    // ---------------------------------------------------------------
+    // Delete matched rows
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testDeleteMatched() {
+        createAndPopulateTable("merge_del", 5);
+
+        // Source contains ids 2 and 4 — delete them from target
+        Dataset<Row> source = createSourceDF(
+                new Object[]{2, "x", 0.0},
+                new Object[]{4, "x", 0.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_del", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().delete()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_del ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        assertEquals(3, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(3, rows.get(1).getInt(0));
+        assertEquals(5, rows.get(2).getInt(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Update with condition (WHEN MATCHED AND condition)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testUpdateWithCondition() {
+        createAndPopulateTable("merge_cond", 5);
+
+        // Source: id=2 (value=200 > 100, should update),
+        //         id=4 (value=50 <= 100, should NOT update)
+        Dataset<Row> source = createSourceDF(
+                new Object[]{2, "updated_2", 200.0},
+                new Object[]{4, "updated_4", 50.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_cond", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched("source.value > 100").updateAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_cond ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        assertEquals(5, rows.size());
+
+        // id=2 should be updated (source.value=200 > 100)
+        assertEquals("updated_2", rows.get(1).getString(1));
+        assertEquals(200.0, rows.get(1).getDouble(2), 0.001);
+
+        // id=4 should be unchanged (source.value=50 <= 100)
+        assertEquals("name_4", rows.get(3).getString(1));
+        assertEquals(40.0, rows.get(3).getDouble(2), 0.001);
+    }
+
+    // ---------------------------------------------------------------
+    // Insert only (no matches)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testInsertOnly() {
+        createAndPopulateTable("merge_ins", 3);
+
+        // Source has only new rows (no matching ids)
+        Dataset<Row> source = createSourceDF(
+                new Object[]{10, "new_10", 100.0},
+                new Object[]{20, "new_20", 200.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_ins", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_ins ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        assertEquals(5, rows.size());
+        assertEquals(10, rows.get(3).getInt(0));
+        assertEquals(20, rows.get(4).getInt(0));
+
+        // Original rows unchanged
+        for (int i = 0; i < 3; i++) {
+            assertEquals(i + 1, rows.get(i).getInt(0));
+            assertEquals("name_" + (i + 1), rows.get(i).getString(1));
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Update only (all match)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testUpdateOnly() {
+        createAndPopulateTable("merge_upd", 3);
+
+        // Source matches all target rows
+        Dataset<Row> source = createSourceDF(
+                new Object[]{1, "upd_1", 100.0},
+                new Object[]{2, "upd_2", 200.0},
+                new Object[]{3, "upd_3", 300.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_upd", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_upd ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        assertEquals(3, rows.size());
+        assertEquals("upd_1", rows.get(0).getString(1));
+        assertEquals("upd_2", rows.get(1).getString(1));
+        assertEquals("upd_3", rows.get(2).getString(1));
+        assertEquals(100.0, rows.get(0).getDouble(2), 0.001);
+        assertEquals(200.0, rows.get(1).getDouble(2), 0.001);
+        assertEquals(300.0, rows.get(2).getDouble(2), 0.001);
+    }
+
+    // ---------------------------------------------------------------
+    // Multiple source rows matching same target row (error)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMultipleSourceMatchesFails() {
+        createAndPopulateTable("merge_dup", 3);
+
+        // Two source rows with the same id=2
+        Dataset<Row> source = createSourceDF(
+                new Object[]{2, "dup_a", 100.0},
+                new Object[]{2, "dup_b", 200.0});
+
+        try {
+            DuckLakeMerge.into(spark, catalogPath, "merge_dup", "main")
+                    .using(source, "source")
+                    .on("target.id = source.id")
+                    .whenMatched().updateAll()
+                    .execute();
+            fail("Should have thrown exception for duplicate source keys");
+        } catch (RuntimeException e) {
+            assertTrue("Error message should mention multiple source rows",
+                    e.getMessage().contains("multiple source rows"));
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Empty source (no-op)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testEmptySource() {
+        createAndPopulateTable("merge_empty", 3);
+
+        // Empty source DataFrame
+        StructType schema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true)
+                .add("value", DataTypes.DoubleType, true);
+        Dataset<Row> source = spark.createDataFrame(
+                Collections.emptyList(), schema);
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_empty", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        // Table should be unchanged
+        assertEquals(3, spark.sql(
+                "SELECT * FROM ducklake.main.merge_empty").count());
+    }
+
+    // ---------------------------------------------------------------
+    // Merge with schema evolution
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMergePreservesColumnsNotInSource() {
+        createAndPopulateTable("merge_schema", 3);
+
+        // Source only has id and name (no value column)
+        StructType srcSchema = new StructType()
+                .add("id", DataTypes.IntegerType, false)
+                .add("name", DataTypes.StringType, true);
+
+        List<Row> srcRows = Arrays.asList(
+                RowFactory.create(2, "updated_2"),
+                RowFactory.create(10, "new_10"));
+        Dataset<Row> source = spark.createDataFrame(srcRows, srcSchema);
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_schema", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_schema ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        assertEquals(4, rows.size());
+
+        // id=2: name updated, value preserved from original
+        assertEquals("updated_2", rows.get(1).getString(1));
+        assertEquals(20.0, rows.get(1).getDouble(2), 0.001);
+
+        // id=10: inserted, value should be null
+        assertEquals("new_10", rows.get(3).getString(1));
+        assertTrue(rows.get(3).isNullAt(2));
+    }
+
+    // ---------------------------------------------------------------
+    // Merge creates new snapshot
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMergeCreatesNewSnapshot() throws Exception {
+        createAndPopulateTable("merge_snap", 3);
+
+        long snapBefore;
+        try (Connection conn = DriverManager.getConnection(
+                "jdbc:sqlite:" + catalogPath)) {
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery(
+                         "SELECT MAX(snapshot_id) FROM ducklake_snapshot")) {
+                rs.next();
+                snapBefore = rs.getLong(1);
+            }
+        }
+
+        Dataset<Row> source = createSourceDF(
+                new Object[]{1, "merged", 999.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_snap", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .execute();
+
+        try (Connection conn = DriverManager.getConnection(
+                "jdbc:sqlite:" + catalogPath)) {
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery(
+                         "SELECT MAX(snapshot_id) FROM ducklake_snapshot")) {
+                rs.next();
+                assertTrue("Merge should create new snapshot",
+                        rs.getLong(1) > snapBefore);
+            }
+
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery(
+                     "SELECT changes_made FROM ducklake_snapshot_changes "
+                     + "WHERE snapshot_id = "
+                     + "(SELECT MAX(snapshot_id) FROM ducklake_snapshot)")) {
+                assertTrue(rs.next());
+                String changes = rs.getString("changes_made");
+                assertTrue("Should record merge changes",
+                        changes.contains("deleted_from_table")
+                        || changes.contains("inserted_into_table"));
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Merge updates table stats correctly
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMergeUpdatesTableStats() throws Exception {
+        createAndPopulateTable("merge_stats", 5);
+
+        // Upsert: update id=3, insert id=10 → 6 total
+        Dataset<Row> source = createSourceDF(
+                new Object[]{3, "upd", 300.0},
+                new Object[]{10, "new", 100.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_stats", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        try (Connection conn = DriverManager.getConnection(
+                "jdbc:sqlite:" + catalogPath)) {
+            long tableId;
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT table_id FROM ducklake_table "
+                    + "WHERE table_name = 'merge_stats' "
+                    + "AND end_snapshot IS NULL")) {
+                ResultSet rs = ps.executeQuery();
+                assertTrue(rs.next());
+                tableId = rs.getLong(1);
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT record_count FROM ducklake_table_stats "
+                    + "WHERE table_id = ?")) {
+                ps.setLong(1, tableId);
+                ResultSet rs = ps.executeQuery();
+                assertTrue(rs.next());
+                assertEquals(6, rs.getLong("record_count"));
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Delete + insert combo via merge
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testDeleteMatchedInsertUnmatched() {
+        createAndPopulateTable("merge_del_ins", 5);
+
+        // id=2,4 match (delete), id=10 doesn't match (insert)
+        Dataset<Row> source = createSourceDF(
+                new Object[]{2, "x", 0.0},
+                new Object[]{4, "x", 0.0},
+                new Object[]{10, "new_10", 100.0});
+
+        DuckLakeMerge.into(spark, catalogPath, "merge_del_ins", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().delete()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_del_ins ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        // 5 - 2 deleted + 1 inserted = 4
+        assertEquals(4, rows.size());
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals(3, rows.get(1).getInt(0));
+        assertEquals(5, rows.get(2).getInt(0));
+        assertEquals(10, rows.get(3).getInt(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Multiple WHEN MATCHED clauses with conditions
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMultipleWhenMatchedClauses() {
+        createAndPopulateTable("merge_multi_when", 5);
+
+        // Source matches id=1 (value=500>100, update),
+        //                id=3 (value=50<=100, delete)
+        Dataset<Row> source = createSourceDF(
+                new Object[]{1, "updated_1", 500.0},
+                new Object[]{3, "updated_3", 50.0});
+
+        DuckLakeMerge.into(spark, catalogPath,
+                    "merge_multi_when", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched("source.value > 100").updateAll()
+                .whenMatched().delete()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_multi_when "
+                + "ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        // id=1 updated, id=3 deleted
+        assertEquals(4, rows.size());
+
+        // id=1 should be updated
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals("updated_1", rows.get(0).getString(1));
+        assertEquals(500.0, rows.get(0).getDouble(2), 0.001);
+
+        // id=3 should be gone
+        assertEquals(2, rows.get(1).getInt(0));
+        assertEquals(4, rows.get(2).getInt(0));
+        assertEquals(5, rows.get(3).getInt(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Merge after delete (interop with existing delete)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMergeAfterDelete() {
+        createAndPopulateTable("merge_after_del", 5);
+
+        // Delete id=2 first
+        spark.sql("DELETE FROM ducklake.main.merge_after_del "
+                + "WHERE id = 2");
+
+        // Now merge: id=3 matches (update), id=2 doesn't match
+        // (was deleted, should insert)
+        Dataset<Row> source = createSourceDF(
+                new Object[]{2, "reinserted_2", 222.0},
+                new Object[]{3, "updated_3", 333.0});
+
+        DuckLakeMerge.into(spark, catalogPath,
+                    "merge_after_del", "main")
+                .using(source, "source")
+                .on("target.id = source.id")
+                .whenMatched().updateAll()
+                .whenNotMatched().insertAll()
+                .execute();
+
+        Dataset<Row> result = spark.sql(
+                "SELECT * FROM ducklake.main.merge_after_del "
+                + "ORDER BY id");
+        List<Row> rows = result.collectAsList();
+
+        // 5 - 1 deleted + 1 re-inserted = 5,
+        // id=3 updated in place
+        assertEquals(5, rows.size());
+
+        // id=2 should be re-inserted
+        Row row2 = findRowById(rows, 2);
+        assertNotNull("id=2 should exist", row2);
+        assertEquals("reinserted_2", row2.getString(1));
+        assertEquals(222.0, row2.getDouble(2), 0.001);
+
+        // id=3 should be updated
+        Row row3 = findRowById(rows, 3);
+        assertNotNull("id=3 should exist", row3);
+        assertEquals("updated_3", row3.getString(1));
+        assertEquals(333.0, row3.getDouble(2), 0.001);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private Row findRowById(List<Row> rows, int id) {
+        for (Row row : rows) {
+            if (row.getInt(0) == id) return row;
+        }
+        return null;
+    }
+
+    // ---------------------------------------------------------------
+    // Catalog setup helper (minimal)
+    // ---------------------------------------------------------------
+
+    private static void createMinimalCatalog(String catPath,
+                                              String dp) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        try (Connection conn = DriverManager.getConnection(
+                "jdbc:sqlite:" + catPath)) {
+            conn.setAutoCommit(false);
+            try (Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE ducklake_metadata("
+                    + "key VARCHAR NOT NULL, "
+                    + "value VARCHAR NOT NULL, "
+                    + "scope VARCHAR, scope_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot("
+                    + "snapshot_id BIGINT PRIMARY KEY, "
+                    + "snapshot_time TEXT, "
+                    + "schema_version BIGINT, "
+                    + "next_catalog_id BIGINT, "
+                    + "next_file_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot_changes("
+                    + "snapshot_id BIGINT PRIMARY KEY, "
+                    + "changes_made VARCHAR, "
+                    + "author VARCHAR, "
+                    + "commit_message VARCHAR, "
+                    + "commit_extra_info VARCHAR)");
+                st.execute("CREATE TABLE ducklake_schema("
+                    + "schema_id BIGINT PRIMARY KEY, "
+                    + "schema_uuid TEXT, "
+                    + "begin_snapshot BIGINT, "
+                    + "end_snapshot BIGINT, "
+                    + "schema_name VARCHAR, "
+                    + "path VARCHAR, "
+                    + "path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_table("
+                    + "table_id BIGINT, table_uuid TEXT, "
+                    + "begin_snapshot BIGINT, "
+                    + "end_snapshot BIGINT, "
+                    + "schema_id BIGINT, "
+                    + "table_name VARCHAR, "
+                    + "path VARCHAR, "
+                    + "path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_column("
+                    + "column_id BIGINT, "
+                    + "begin_snapshot BIGINT, "
+                    + "end_snapshot BIGINT, "
+                    + "table_id BIGINT, "
+                    + "column_order BIGINT, "
+                    + "column_name VARCHAR, "
+                    + "column_type VARCHAR, "
+                    + "initial_default VARCHAR, "
+                    + "default_value VARCHAR, "
+                    + "nulls_allowed BOOLEAN, "
+                    + "parent_column BIGINT, "
+                    + "default_value_type VARCHAR, "
+                    + "default_value_dialect VARCHAR)");
+                st.execute("CREATE TABLE ducklake_data_file("
+                    + "data_file_id BIGINT PRIMARY KEY, "
+                    + "table_id BIGINT, "
+                    + "begin_snapshot BIGINT, "
+                    + "end_snapshot BIGINT, "
+                    + "file_order BIGINT, "
+                    + "path VARCHAR, "
+                    + "path_is_relative BOOLEAN, "
+                    + "file_format VARCHAR, "
+                    + "record_count BIGINT, "
+                    + "file_size_bytes BIGINT, "
+                    + "footer_size BIGINT, "
+                    + "row_id_start BIGINT, "
+                    + "partition_id BIGINT, "
+                    + "encryption_key VARCHAR, "
+                    + "mapping_id BIGINT, "
+                    + "partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_column_stats("
+                    + "data_file_id BIGINT, "
+                    + "table_id BIGINT, "
+                    + "column_id BIGINT, "
+                    + "column_size_bytes BIGINT, "
+                    + "value_count BIGINT, "
+                    + "null_count BIGINT, "
+                    + "min_value VARCHAR, "
+                    + "max_value VARCHAR, "
+                    + "contains_nan BOOLEAN, "
+                    + "extra_stats VARCHAR)");
+                st.execute("CREATE TABLE ducklake_table_stats("
+                    + "table_id BIGINT, "
+                    + "record_count BIGINT, "
+                    + "next_row_id BIGINT, "
+                    + "file_size_bytes BIGINT)");
+                st.execute("CREATE TABLE ducklake_delete_file("
+                    + "delete_file_id BIGINT PRIMARY KEY, "
+                    + "table_id BIGINT, "
+                    + "begin_snapshot BIGINT, "
+                    + "end_snapshot BIGINT, "
+                    + "data_file_id BIGINT, "
+                    + "path VARCHAR, "
+                    + "path_is_relative BOOLEAN, "
+                    + "format VARCHAR, "
+                    + "delete_count BIGINT, "
+                    + "file_size_bytes BIGINT, "
+                    + "footer_size BIGINT, "
+                    + "encryption_key VARCHAR, "
+                    + "partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_name_mapping("
+                    + "mapping_id BIGINT, "
+                    + "column_id BIGINT, "
+                    + "source_name VARCHAR, "
+                    + "target_field_id BIGINT, "
+                    + "parent_column BIGINT, "
+                    + "is_partition BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_inlined_data_tables("
+                    + "table_id BIGINT, "
+                    + "table_name VARCHAR, "
+                    + "schema_version BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_partition_value("
+                    + "data_file_id BIGINT, "
+                    + "table_id BIGINT, "
+                    + "partition_key_index BIGINT, "
+                    + "partition_value VARCHAR)");
+
+                st.execute("INSERT INTO ducklake_metadata (key, value) "
+                    + "VALUES ('version', '0.4')");
+                st.execute("INSERT INTO ducklake_metadata (key, value) "
+                    + "VALUES ('data_path', '" + dp + "')");
+
+                st.execute("INSERT INTO ducklake_snapshot VALUES "
+                    + "(0, datetime('now'), 0, 1, 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES "
+                    + "(0, 'created_schema:\"main\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_schema VALUES "
+                    + "(0, 'schema-uuid-0', 0, NULL, 'main', "
+                    + "'main/', 1)");
+            }
+            conn.commit();
+        }
+    }
+
+    private static void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
## MERGE INTO Support (PR 7 from Roadmap Issue #1)

Implements the most-requested lakehouse operation — MERGE INTO — for DuckLake tables via Spark.

### API

```java
DuckLakeMerge.into(spark, catalogPath, "target_table", "main")
    .using(sourceDF, "source")
    .on("target.id = source.id")
    .whenMatched().updateAll()
    .whenNotMatched().insertAll()
    .execute();
```

### Supported Operations

| Clause | Actions |
|--------|---------|
| `whenMatched()` | `updateAll()`, `update(assignments)`, `delete()` |
| `whenMatched(condition)` | Same, with additional predicate filter |
| `whenNotMatched()` | `insertAll()`, `insert(assignments)` |
| `whenNotMatched(condition)` | Same, with additional predicate filter |

### Implementation

- **Copy-on-write semantics**: delete files mark old row versions, new data files hold updated/inserted rows
- **Hash-join matching**: source rows indexed by join key(s) for O(1) target→source lookup
- **Atomic commits**: all changes (deletes + inserts + updates) committed in a single snapshot
- **Cardinality validation**: rejects multiple source rows matching the same target row
- **Schema evolution**: preserves target columns not present in source during updates
- **Column stats**: full min/max/null/value count tracking on new data files
- **Compound conditions**: ON clause supports AND, WHEN clauses support comparison operators

### Tests (13 new, 144 total)

- Basic upsert (update matched + insert unmatched)
- Delete matched rows
- Update with condition (`WHEN MATCHED AND source.value > 100`)
- Insert only (no matches in target)
- Update only (all source rows match)
- Multiple source rows matching same target row (error validation)
- Empty source (no-op)
- Schema evolution (source missing columns — target values preserved)
- Snapshot creation verification
- Table stats correctness after merge
- Delete + insert combo via merge
- Multiple WHEN MATCHED clauses with priority ordering
- Merge after prior DELETE operations (interop)

### Files Changed

- **New**: `DuckLakeMerge.java` — builder-pattern merge API + executor
- **New**: `DuckLakeMergeTest.java` — 13 integration tests
- **Modified**: `DuckLakeDeleteExecutor.java` — made `writeDeleteFile()` public
- **Modified**: `DuckLakeRowFilterEvaluator.java` — made `compareValues()` public

Closes #1 (PR 7)