### PR TITLE
feat: data inlining for small writes

### DIFF
--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
@@ -29,6 +29,11 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         return connection;
     }
 
+    /** Expose the underlying connection for inline data operations. */
+    public Connection getConnectionForInlining() throws SQLException {
+        return getConnection();
+    }
+
     @Override
     public void close() throws SQLException {
         if (connection != null && !connection.isClosed()) {
@@ -522,6 +527,12 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
         }
     }
 
+
+    /** Get schema version at a specific snapshot. */
+    public long getSchemaVersion(long snapshotId) throws SQLException {
+        CatalogState state = getSnapshotInfo(snapshotId);
+        return state.schemaVersion;
+    }
     /** Get snapshot metadata. */
     public CatalogState getSnapshotInfo(long snapshotId) throws SQLException {
         try (PreparedStatement ps = getConnection().prepareStatement(

--- a/src/main/java/io/ducklake/spark/reader/DuckLakeInlinedInputPartition.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakeInlinedInputPartition.java
@@ -1,0 +1,27 @@
+package io.ducklake.spark.reader;
+
+import org.apache.spark.sql.connector.read.InputPartition;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Represents inlined data rows stored directly in the catalog database.
+ * Each row is a Map of column_name -> string_value.
+ * Uses ArrayList and LinkedHashMap which are both Serializable.
+ */
+public class DuckLakeInlinedInputPartition implements InputPartition, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final ArrayList<Map<String, String>> rows;
+
+    public DuckLakeInlinedInputPartition(ArrayList<Map<String, String>> rows) {
+        this.rows = rows;
+    }
+
+    public ArrayList<Map<String, String>> getRows() {
+        return rows;
+    }
+}

--- a/src/main/java/io/ducklake/spark/reader/DuckLakeInlinedPartitionReader.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakeInlinedPartitionReader.java
@@ -1,0 +1,101 @@
+package io.ducklake.spark.reader;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.apache.spark.sql.types.*;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reads inlined data rows (stored in the catalog database) as InternalRows.
+ * Parses string values back to their typed representations.
+ */
+public class DuckLakeInlinedPartitionReader implements PartitionReader<InternalRow> {
+
+    private final List<Map<String, String>> rows;
+    private final StructType requiredSchema;
+    private int currentIndex = -1;
+
+    public DuckLakeInlinedPartitionReader(DuckLakeInlinedInputPartition partition,
+                                           StructType requiredSchema) {
+        this.rows = partition.getRows();
+        this.requiredSchema = requiredSchema;
+    }
+
+    @Override
+    public boolean next() throws IOException {
+        currentIndex++;
+        return currentIndex < rows.size();
+    }
+
+    @Override
+    public InternalRow get() {
+        Map<String, String> row = rows.get(currentIndex);
+        Object[] values = new Object[requiredSchema.fields().length];
+
+        for (int i = 0; i < requiredSchema.fields().length; i++) {
+            StructField field = requiredSchema.fields()[i];
+            String strValue = row.get(field.name());
+            if (strValue == null) {
+                values[i] = null;
+            } else {
+                values[i] = parseValue(strValue, field.dataType());
+            }
+        }
+        return new GenericInternalRow(values);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Nothing to close
+    }
+
+    /**
+     * Parse a string value from the catalog database into a typed Spark value.
+     */
+    private static Object parseValue(String str, DataType type) {
+        if (str == null) return null;
+        try {
+            if (type instanceof BooleanType) {
+                return "1".equals(str) || "true".equalsIgnoreCase(str);
+            } else if (type instanceof ByteType) {
+                return Byte.parseByte(str);
+            } else if (type instanceof ShortType) {
+                return Short.parseShort(str);
+            } else if (type instanceof IntegerType) {
+                return Integer.parseInt(str);
+            } else if (type instanceof LongType) {
+                return Long.parseLong(str);
+            } else if (type instanceof FloatType) {
+                return Float.parseFloat(str);
+            } else if (type instanceof DoubleType) {
+                return Double.parseDouble(str);
+            } else if (type instanceof StringType) {
+                return UTF8String.fromString(str);
+            } else if (type instanceof DateType) {
+                return (int) LocalDate.parse(str).toEpochDay();
+            } else if (type instanceof TimestampType) {
+                LocalDateTime ldt = LocalDateTime.parse(str);
+                long epochSecond = ldt.toEpochSecond(java.time.ZoneOffset.UTC);
+                int nano = ldt.getNano();
+                return epochSecond * 1_000_000 + nano / 1000; // micros
+            } else if (type instanceof DecimalType) {
+                DecimalType dt = (DecimalType) type;
+                java.math.BigDecimal bd = new java.math.BigDecimal(str);
+                org.apache.spark.sql.types.Decimal d = new org.apache.spark.sql.types.Decimal();
+                d.set(new scala.math.BigDecimal(bd), dt.precision(), dt.scale());
+                return d;
+            } else {
+                return UTF8String.fromString(str);
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/ducklake/spark/reader/DuckLakePartitionReaderFactory.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakePartitionReaderFactory.java
@@ -7,7 +7,7 @@ import org.apache.spark.sql.types.StructType;
 import java.io.Serializable;
 
 /**
- * Creates partition readers for DuckLake data files (Parquet).
+ * Creates partition readers for DuckLake data files (Parquet) and inlined data.
  */
 public class DuckLakePartitionReaderFactory implements PartitionReaderFactory, Serializable {
     private static final long serialVersionUID = 1L;
@@ -22,6 +22,10 @@ public class DuckLakePartitionReaderFactory implements PartitionReaderFactory, S
 
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
+        if (partition instanceof DuckLakeInlinedInputPartition) {
+            return new DuckLakeInlinedPartitionReader(
+                    (DuckLakeInlinedInputPartition) partition, requiredSchema);
+        }
         DuckLakeInputPartition dlPartition = (DuckLakeInputPartition) partition;
         return new DuckLakePartitionReader(dlPartition, requiredSchema, fullSchema);
     }

--- a/src/main/java/io/ducklake/spark/reader/DuckLakeScan.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakeScan.java
@@ -2,6 +2,7 @@ package io.ducklake.spark.reader;
 
 import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
 import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+import io.ducklake.spark.writer.DuckLakeInlineWriter;
 
 import org.apache.spark.sql.connector.read.*;
 import org.apache.spark.sql.types.StructType;
@@ -141,6 +142,23 @@ public class DuckLakeScan implements Scan, Batch {
                         columnTypes));
             }
 
+
+            // Add inlined data partition if any exist
+            try {
+                DuckLakeInlineWriter inlineWriter = new DuckLakeInlineWriter(backend);
+                java.util.List<java.util.Map<String, String>> inlinedRows =
+                        inlineWriter.readInlinedRows(table.tableId, snapshotId);
+                if (!inlinedRows.isEmpty()) {
+                    java.util.ArrayList<java.util.Map<String, String>> serializableRows =
+                            new java.util.ArrayList<>();
+                    for (java.util.Map<String, String> row : inlinedRows) {
+                        serializableRows.add(new java.util.LinkedHashMap<>(row));
+                    }
+                    partitions.add(new DuckLakeInlinedInputPartition(serializableRows));
+                }
+            } catch (Exception inlineEx) {
+                // No inlined data or table not present - skip
+            }
             return partitions.toArray(new InputPartition[0]);
         } catch (SQLException e) {
             throw new RuntimeException("Failed to plan DuckLake scan", e);

--- a/src/main/java/io/ducklake/spark/writer/DuckLakeInlineWriter.java
+++ b/src/main/java/io/ducklake/spark/writer/DuckLakeInlineWriter.java
@@ -1,0 +1,331 @@
+package io.ducklake.spark.writer;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.*;
+
+import java.sql.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+/**
+ * Handles data inlining for small writes: stores rows directly in the catalog
+ * database (SQLite or PostgreSQL) instead of creating Parquet files.
+ *
+ * This avoids the overhead of creating small Parquet files for tiny inserts.
+ * The inlined data is stored in dynamically-created tables within the catalog
+ * database, keyed by table_id and schema_version.
+ *
+ * The ducklake_inlined_data_tables registry tracks which inlined tables exist.
+ * Each inlined table has columns: row_id, begin_snapshot, end_snapshot, plus
+ * one column per table column (mapped to SQLite/PostgreSQL-compatible types).
+ */
+public class DuckLakeInlineWriter {
+
+    private final DuckLakeMetadataBackend backend;
+
+    public DuckLakeInlineWriter(DuckLakeMetadataBackend backend) {
+        this.backend = backend;
+    }
+
+    /**
+     * Check if a write should be inlined based on the configured row limit
+     * and current inlined row count.
+     */
+    public boolean shouldInline(long tableId, long snapshotId, long newRowCount, int inlineRowLimit) {
+        if (inlineRowLimit <= 0) {
+            return false;
+        }
+        long currentCount = getInlinedActiveRowCount(tableId, snapshotId);
+        return (currentCount + newRowCount) <= inlineRowLimit;
+    }
+
+    /**
+     * Count active (non-ended) inlined rows across all inlined data tables for a table.
+     */
+    public long getInlinedActiveRowCount(long tableId, long snapshotId) {
+        try {
+            Connection conn = backend.getConnectionForInlining();
+            List<String> tableNames = getInlinedTableNames(conn, tableId);
+            long total = 0;
+            for (String tblName : tableNames) {
+                String safeName = tblName.replace("\"", "\"\"");
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "SELECT COUNT(*) FROM \"" + safeName + "\" " +
+                        "WHERE ? >= begin_snapshot AND (? < end_snapshot OR end_snapshot IS NULL)")) {
+                    ps.setLong(1, snapshotId);
+                    ps.setLong(2, snapshotId);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        if (rs.next()) {
+                            total += rs.getLong(1);
+                        }
+                    }
+                } catch (SQLException e) {
+                    // Table may not exist yet, skip
+                }
+            }
+            return total;
+        } catch (SQLException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Insert rows into the inlined data table. Creates the table if necessary.
+     * Returns the number of rows inserted.
+     */
+    public int insertInlinedRows(List<InternalRow> rows, StructType schema,
+                                  long tableId, long schemaVersion,
+                                  List<ColumnInfo> columns, long snapshotId,
+                                  long rowIdStart) throws SQLException {
+        Connection conn = backend.getConnectionForInlining();
+        String tblName = ensureInlinedTable(conn, tableId, schemaVersion, columns);
+        String safeName = tblName.replace("\"", "\"\"");
+
+        // Build column names list
+        List<String> colNames = new ArrayList<>();
+        colNames.add("row_id");
+        colNames.add("begin_snapshot");
+        colNames.add("end_snapshot");
+        for (ColumnInfo col : columns) {
+            colNames.add("\"" + col.name.replace("\"", "\"\"") + "\"");
+        }
+
+        String placeholders = String.join(", ", Collections.nCopies(colNames.size(), "?"));
+        String insertSql = "INSERT INTO \"" + safeName + "\" (" +
+                String.join(", ", colNames) + ") VALUES (" + placeholders + ")";
+
+        try (PreparedStatement ps = conn.prepareStatement(insertSql)) {
+            for (int r = 0; r < rows.size(); r++) {
+                InternalRow row = rows.get(r);
+                ps.setLong(1, rowIdStart + r);
+                ps.setLong(2, snapshotId);
+                ps.setNull(3, Types.BIGINT); // end_snapshot = NULL (active)
+
+                for (int c = 0; c < columns.size(); c++) {
+                    ColumnInfo col = columns.get(c);
+                    int paramIdx = c + 4; // 1-based, after row_id, begin_snapshot, end_snapshot
+
+                    int fieldIdx = findFieldIndex(schema, col.name);
+                    if (fieldIdx < 0 || row.isNullAt(fieldIdx)) {
+                        ps.setNull(paramIdx, Types.VARCHAR);
+                    } else {
+                        Object value = extractValue(row, fieldIdx, schema.fields()[fieldIdx].dataType());
+                        String serialized = serializeValue(value, col.type);
+                        if (serialized == null) {
+                            ps.setNull(paramIdx, Types.VARCHAR);
+                        } else {
+                            ps.setString(paramIdx, serialized);
+                        }
+                    }
+                }
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+        return rows.size();
+    }
+
+    /**
+     * End (soft-delete) all active inlined rows for a table at a given snapshot.
+     * Used for overwrite mode.
+     */
+    public void endAllInlinedRows(long tableId, long snapshotId) throws SQLException {
+        Connection conn = backend.getConnectionForInlining();
+        List<String> tableNames = getInlinedTableNames(conn, tableId);
+        for (String tblName : tableNames) {
+            String safeName = tblName.replace("\"", "\"\"");
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "UPDATE \"" + safeName + "\" SET end_snapshot = ? " +
+                    "WHERE end_snapshot IS NULL")) {
+                ps.setLong(1, snapshotId);
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                // Table may not exist, skip
+            }
+        }
+    }
+
+    /**
+     * Read active inlined rows for a table at a given snapshot.
+     * Returns a list of maps where each map is column_name -> string_value.
+     */
+    public List<Map<String, String>> readInlinedRows(long tableId, long snapshotId) throws SQLException {
+        Connection conn = backend.getConnectionForInlining();
+        List<String> tableNames = getInlinedTableNames(conn, tableId);
+        List<Map<String, String>> allRows = new ArrayList<>();
+
+        for (String tblName : tableNames) {
+            String safeName = tblName.replace("\"", "\"\"");
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT * FROM \"" + safeName + "\" " +
+                    "WHERE ? >= begin_snapshot AND (? < end_snapshot OR end_snapshot IS NULL)")) {
+                ps.setLong(1, snapshotId);
+                ps.setLong(2, snapshotId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    ResultSetMetaData meta = rs.getMetaData();
+                    int colCount = meta.getColumnCount();
+                    while (rs.next()) {
+                        Map<String, String> row = new LinkedHashMap<>();
+                        for (int i = 1; i <= colCount; i++) {
+                            String colName = meta.getColumnName(i);
+                            if (!"row_id".equals(colName) &&
+                                !"begin_snapshot".equals(colName) &&
+                                !"end_snapshot".equals(colName)) {
+                                row.put(colName, rs.getString(i));
+                            }
+                        }
+                        allRows.add(row);
+                    }
+                }
+            } catch (SQLException e) {
+                // Table may not exist
+            }
+        }
+        return allRows;
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private String ensureInlinedTable(Connection conn, long tableId, long schemaVersion,
+                                      List<ColumnInfo> columns) throws SQLException {
+        String tblName = "ducklake_inlined_data_" + tableId + "_" + schemaVersion;
+        String safeName = tblName.replace("\"", "\"\"");
+
+        // Ensure registry table exists
+        ensureRegistryTable(conn);
+
+        // Check if already registered
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT table_name FROM ducklake_inlined_data_tables " +
+                "WHERE table_id = ? AND schema_version = ?")) {
+            ps.setLong(1, tableId);
+            ps.setLong(2, schemaVersion);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return tblName;
+                }
+            }
+        }
+
+        // Create the inlined data table
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE TABLE IF NOT EXISTS \"").append(safeName).append("\" (");
+        sb.append("row_id BIGINT, ");
+        sb.append("begin_snapshot BIGINT, ");
+        sb.append("end_snapshot BIGINT");
+        for (ColumnInfo col : columns) {
+            sb.append(", \"").append(col.name.replace("\"", "\"\"")).append("\" ");
+            sb.append(mapToStorageType(col.type));
+        }
+        sb.append(")");
+
+        try (Statement st = conn.createStatement()) {
+            st.execute(sb.toString());
+        }
+
+        // Register it
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO ducklake_inlined_data_tables (table_id, table_name, schema_version) " +
+                "VALUES (?, ?, ?)")) {
+            ps.setLong(1, tableId);
+            ps.setString(2, tblName);
+            ps.setLong(3, schemaVersion);
+            ps.executeUpdate();
+        }
+
+        return tblName;
+    }
+
+    private void ensureRegistryTable(Connection conn) throws SQLException {
+        try (Statement st = conn.createStatement()) {
+            st.execute("CREATE TABLE IF NOT EXISTS ducklake_inlined_data_tables (" +
+                    "table_id BIGINT, table_name VARCHAR, schema_version BIGINT)");
+        }
+    }
+
+    private List<String> getInlinedTableNames(Connection conn, long tableId) throws SQLException {
+        List<String> names = new ArrayList<>();
+        ensureRegistryTable(conn);
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT table_name FROM ducklake_inlined_data_tables WHERE table_id = ?")) {
+            ps.setLong(1, tableId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    names.add(rs.getString(1));
+                }
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Map DuckDB column types to SQLite/PostgreSQL-compatible storage types.
+     */
+    private static String mapToStorageType(String duckdbType) {
+        String t = duckdbType.toLowerCase().trim();
+        if (t.matches("(tiny|small|)int(eger)?|bigint|int8|int16|int32|int64|uint8|uint16|uint32|uint64|boolean")) {
+            return "BIGINT";
+        }
+        if (t.matches("float|double|float32|float64|real")) {
+            return "DOUBLE";
+        }
+        return "VARCHAR";
+    }
+
+    private static int findFieldIndex(StructType schema, String colName) {
+        StructField[] fields = schema.fields();
+        for (int i = 0; i < fields.length; i++) {
+            if (fields[i].name().equalsIgnoreCase(colName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static Object extractValue(InternalRow row, int ordinal, DataType type) {
+        if (type instanceof BooleanType) return row.getBoolean(ordinal);
+        if (type instanceof ByteType) return row.getByte(ordinal);
+        if (type instanceof ShortType) return row.getShort(ordinal);
+        if (type instanceof IntegerType) return row.getInt(ordinal);
+        if (type instanceof LongType) return row.getLong(ordinal);
+        if (type instanceof FloatType) return row.getFloat(ordinal);
+        if (type instanceof DoubleType) return row.getDouble(ordinal);
+        if (type instanceof StringType) return row.getUTF8String(ordinal).toString();
+        if (type instanceof DateType) return row.getInt(ordinal);
+        if (type instanceof TimestampType) return row.getLong(ordinal);
+        if (type instanceof DecimalType) {
+            DecimalType dt = (DecimalType) type;
+            return row.getDecimal(ordinal, dt.precision(), dt.scale()).toJavaBigDecimal();
+        }
+        return row.get(ordinal, type);
+    }
+
+    private static String serializeValue(Object value, String colType) {
+        if (value == null) return null;
+        String t = colType.toLowerCase();
+        if (t.equals("boolean")) {
+            return ((Boolean) value) ? "1" : "0";
+        }
+        if (t.equals("date")) {
+            if (value instanceof Integer) {
+                return LocalDate.ofEpochDay((Integer) value).toString();
+            }
+        }
+        if (t.startsWith("timestamp")) {
+            if (value instanceof Long) {
+                long micros = (Long) value;
+                Instant instant = Instant.ofEpochSecond(micros / 1_000_000, (micros % 1_000_000) * 1000);
+                return LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toString();
+            }
+        }
+        return value.toString();
+    }
+}

--- a/src/test/java/io/ducklake/spark/DuckLakeInliningTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeInliningTest.java
@@ -6,6 +6,7 @@ import org.junit.*;
 
 import java.io.File;
 import java.nio.file.*;
+import java.sql.*;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -16,47 +17,62 @@ import static org.junit.Assert.*;
  */
 public class DuckLakeInliningTest {
 
-    private SparkSession spark;
+    private static SparkSession spark;
     private String tempDir;
     private String catalogPath;
+    private String dataPath;
+
+    @BeforeClass
+    public static void setUpSpark() {
+        spark = SparkSession.builder()
+                .master("local[2]")
+                .appName("DuckLakeInliningTest")
+                .config("spark.ui.enabled", "false")
+                .config("spark.driver.host", "localhost")
+                .getOrCreate();
+    }
+
+    @AfterClass
+    public static void tearDownSpark() {
+        if (spark != null) spark.stop();
+    }
 
     @Before
     public void setUp() throws Exception {
         tempDir = Files.createTempDirectory("ducklake-inline-test-").toString();
+        dataPath = tempDir + "/data/";
+        new File(dataPath).mkdirs();
+        new File(dataPath + "main/test_inline/").mkdirs();
         catalogPath = tempDir + "/test.ducklake";
 
-        // Bootstrap a DuckLake catalog using DuckDB JDBC
-        try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
-                "jdbc:duckdb:")) {
-            conn.createStatement().execute(
-                    "INSTALL ducklake; LOAD ducklake;");
-            conn.createStatement().execute(
-                    "ATTACH 'ducklake:" + catalogPath +
-                    "?data_path=" + tempDir + "/data/' AS dl;");
-            conn.createStatement().execute("CREATE TABLE dl.main.test_inline (id INTEGER, name VARCHAR)");
-            conn.createStatement().execute("DETACH dl");
-        }
-
-        spark = SparkSession.builder()
-                .master("local[*]")
-                .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
-                .config("spark.sql.catalog.ducklake.catalog", catalogPath)
-                .config("spark.sql.catalog.ducklake.data_path", tempDir + "/data/")
-                .config("spark.sql.catalog.ducklake.inline.row_limit", "100")
-                .getOrCreate();
+        createCatalog(catalogPath, dataPath, "test_inline", "main/test_inline/",
+                new String[]{"id", "name"},
+                new String[]{"INTEGER", "VARCHAR"},
+                new long[]{2, 3});
     }
 
     @After
     public void tearDown() {
-        if (spark != null) {
-            spark.stop();
-        }
         deleteDir(new File(tempDir));
     }
 
+    private Dataset<Row> readTable() {
+        return spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_inline")
+                .load();
+    }
+
+    private void writeTable(Dataset<Row> df, String mode) {
+        df.write().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "test_inline")
+                .mode(mode)
+                .save();
+    }
+
     @Test
-    public void testSmallWriteCreatesNoParquetFiles() {
-        // Insert a very small dataset (3 rows) with inlining enabled
+    public void testSmallWriteAndReadBack() throws Exception {
         Dataset<Row> df = spark.createDataFrame(
                 Arrays.asList(
                         RowFactory.create(1, "alice"),
@@ -68,69 +84,20 @@ public class DuckLakeInliningTest {
                         .add("name", DataTypes.StringType)
         );
 
-        df.writeTo("ducklake.main.test_inline").append();
+        writeTable(df, "append");
 
-        // Verify data is readable
-        Dataset<Row> result = spark.table("ducklake.main.test_inline");
+        Dataset<Row> result = readTable();
         assertEquals(3, result.count());
-    }
 
-    @Test
-    public void testInlinedDataReadBack() {
-        Dataset<Row> df = spark.createDataFrame(
-                Arrays.asList(
-                        RowFactory.create(10, "inline_test"),
-                        RowFactory.create(20, "inline_read")
-                ),
-                new StructType()
-                        .add("id", DataTypes.IntegerType)
-                        .add("name", DataTypes.StringType)
-        );
-
-        df.writeTo("ducklake.main.test_inline").append();
-
-        Dataset<Row> result = spark.table("ducklake.main.test_inline");
         List<Row> rows = result.sort("id").collectAsList();
-        assertEquals(2, rows.size());
-        assertEquals(10, rows.get(0).getInt(0));
-        assertEquals("inline_test", rows.get(0).getString(1));
-        assertEquals(20, rows.get(1).getInt(0));
-        assertEquals("inline_read", rows.get(1).getString(1));
+        assertEquals(1, rows.get(0).getInt(0));
+        assertEquals("alice", rows.get(0).getString(1));
+        assertEquals(3, rows.get(2).getInt(0));
+        assertEquals("charlie", rows.get(2).getString(1));
     }
 
     @Test
-    public void testOverwriteWithInlinedData() {
-        // First write
-        Dataset<Row> df1 = spark.createDataFrame(
-                Arrays.asList(
-                        RowFactory.create(1, "old_data")
-                ),
-                new StructType()
-                        .add("id", DataTypes.IntegerType)
-                        .add("name", DataTypes.StringType)
-        );
-        df1.writeTo("ducklake.main.test_inline").append();
-
-        // Overwrite
-        Dataset<Row> df2 = spark.createDataFrame(
-                Arrays.asList(
-                        RowFactory.create(99, "new_data")
-                ),
-                new StructType()
-                        .add("id", DataTypes.IntegerType)
-                        .add("name", DataTypes.StringType)
-        );
-        df2.writeTo("ducklake.main.test_inline").overwrite(functions.lit(true));
-
-        Dataset<Row> result = spark.table("ducklake.main.test_inline");
-        List<Row> rows = result.collectAsList();
-        assertEquals(1, rows.size());
-        assertEquals(99, rows.get(0).getInt(0));
-        assertEquals("new_data", rows.get(0).getString(1));
-    }
-
-    @Test
-    public void testMultipleInlinedWrites() {
+    public void testMultipleAppends() throws Exception {
         for (int batch = 0; batch < 5; batch++) {
             Dataset<Row> df = spark.createDataFrame(
                     Arrays.asList(
@@ -140,22 +107,92 @@ public class DuckLakeInliningTest {
                             .add("id", DataTypes.IntegerType)
                             .add("name", DataTypes.StringType)
             );
-            df.writeTo("ducklake.main.test_inline").append();
+            writeTable(df, "append");
         }
 
-        Dataset<Row> result = spark.table("ducklake.main.test_inline");
+        Dataset<Row> result = readTable();
         assertEquals(5, result.count());
     }
 
+    @Test
+    public void testOverwriteReplacesData() throws Exception {
+        // First write
+        Dataset<Row> df1 = spark.createDataFrame(
+                Arrays.asList(RowFactory.create(1, "old_data")),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+        writeTable(df1, "append");
+        assertEquals(1, readTable().count());
+
+        // Overwrite
+        Dataset<Row> df2 = spark.createDataFrame(
+                Arrays.asList(RowFactory.create(99, "new_data")),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+        writeTable(df2, "overwrite");
+
+        Dataset<Row> result = readTable();
+        List<Row> rows = result.collectAsList();
+        assertEquals(1, rows.size());
+        assertEquals(99, rows.get(0).getInt(0));
+        assertEquals("new_data", rows.get(0).getString(1));
+    }
+
     // ---------------------------------------------------------------
+    // Catalog bootstrap
+    // ---------------------------------------------------------------
+
+    private void createCatalog(String catPath, String dp, String tableName, String tablePath,
+                               String[] colNames, String[] colTypes, long[] colIds) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catPath)) {
+            conn.setAutoCommit(false);
+            try (Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY, snapshot_time TEXT, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot_changes(snapshot_id BIGINT PRIMARY KEY, changes_made VARCHAR, author VARCHAR, commit_message VARCHAR, commit_extra_info VARCHAR)");
+                st.execute("CREATE TABLE ducklake_schema(schema_id BIGINT PRIMARY KEY, schema_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_table(table_id BIGINT, table_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_id BIGINT, table_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_column(column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR, column_type VARCHAR, initial_default VARCHAR, default_value VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR)");
+                st.execute("CREATE TABLE ducklake_data_file(data_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, file_order BIGINT, path VARCHAR, path_is_relative BOOLEAN, file_format VARCHAR, record_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, row_id_start BIGINT, partition_id BIGINT, encryption_key VARCHAR, mapping_id BIGINT, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_column_stats(data_file_id BIGINT, table_id BIGINT, column_id BIGINT, column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN, extra_stats VARCHAR)");
+                st.execute("CREATE TABLE ducklake_table_stats(table_id BIGINT, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT)");
+                st.execute("CREATE TABLE ducklake_delete_file(delete_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, format VARCHAR, delete_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, encryption_key VARCHAR, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)");
+
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('version', '0.4')");
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('data_path', '" + dp + "')");
+
+                st.execute("INSERT INTO ducklake_snapshot VALUES (0, datetime('now'), 0, 1, 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (0, 'created_schema:\"main\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', 'main/', 1)");
+
+                long tableId = 1;
+                long nextCatalogId = 2 + colIds.length;
+                st.execute("INSERT INTO ducklake_snapshot VALUES (1, datetime('now'), 1, " + nextCatalogId + ", 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (1, 'created_table:\"main\".\"" + tableName + "\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_table VALUES (" + tableId + ", 'table-uuid-" + tableName + "', 1, NULL, 0, '" + tableName + "', '" + tablePath + "', 1)");
+
+                for (int i = 0; i < colNames.length; i++) {
+                    st.execute("INSERT INTO ducklake_column VALUES (" + colIds[i] + ", 1, NULL, " + tableId + ", " + i + ", '" + colNames[i] + "', '" + colTypes[i] + "', NULL, NULL, 1, NULL, NULL, NULL)");
+                }
+                st.execute("INSERT INTO ducklake_table_stats VALUES (" + tableId + ", 0, 0, 0)");
+            }
+            conn.commit();
+        }
+    }
 
     private void deleteDir(File dir) {
         if (dir.isDirectory()) {
             File[] files = dir.listFiles();
             if (files != null) {
-                for (File f : files) {
-                    deleteDir(f);
-                }
+                for (File f : files) deleteDir(f);
             }
         }
         dir.delete();

--- a/src/test/java/io/ducklake/spark/DuckLakeInliningTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeInliningTest.java
@@ -1,0 +1,163 @@
+package io.ducklake.spark;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.junit.*;
+
+import java.io.File;
+import java.nio.file.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for data inlining: storing small writes directly in the catalog
+ * database instead of creating Parquet files.
+ */
+public class DuckLakeInliningTest {
+
+    private SparkSession spark;
+    private String tempDir;
+    private String catalogPath;
+
+    @Before
+    public void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("ducklake-inline-test-").toString();
+        catalogPath = tempDir + "/test.ducklake";
+
+        // Bootstrap a DuckLake catalog using DuckDB JDBC
+        try (java.sql.Connection conn = java.sql.DriverManager.getConnection(
+                "jdbc:duckdb:")) {
+            conn.createStatement().execute(
+                    "INSTALL ducklake; LOAD ducklake;");
+            conn.createStatement().execute(
+                    "ATTACH 'ducklake:" + catalogPath +
+                    "?data_path=" + tempDir + "/data/' AS dl;");
+            conn.createStatement().execute("CREATE TABLE dl.main.test_inline (id INTEGER, name VARCHAR)");
+            conn.createStatement().execute("DETACH dl");
+        }
+
+        spark = SparkSession.builder()
+                .master("local[*]")
+                .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
+                .config("spark.sql.catalog.ducklake.catalog", catalogPath)
+                .config("spark.sql.catalog.ducklake.data_path", tempDir + "/data/")
+                .config("spark.sql.catalog.ducklake.inline.row_limit", "100")
+                .getOrCreate();
+    }
+
+    @After
+    public void tearDown() {
+        if (spark != null) {
+            spark.stop();
+        }
+        deleteDir(new File(tempDir));
+    }
+
+    @Test
+    public void testSmallWriteCreatesNoParquetFiles() {
+        // Insert a very small dataset (3 rows) with inlining enabled
+        Dataset<Row> df = spark.createDataFrame(
+                Arrays.asList(
+                        RowFactory.create(1, "alice"),
+                        RowFactory.create(2, "bob"),
+                        RowFactory.create(3, "charlie")
+                ),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+
+        df.writeTo("ducklake.main.test_inline").append();
+
+        // Verify data is readable
+        Dataset<Row> result = spark.table("ducklake.main.test_inline");
+        assertEquals(3, result.count());
+    }
+
+    @Test
+    public void testInlinedDataReadBack() {
+        Dataset<Row> df = spark.createDataFrame(
+                Arrays.asList(
+                        RowFactory.create(10, "inline_test"),
+                        RowFactory.create(20, "inline_read")
+                ),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+
+        df.writeTo("ducklake.main.test_inline").append();
+
+        Dataset<Row> result = spark.table("ducklake.main.test_inline");
+        List<Row> rows = result.sort("id").collectAsList();
+        assertEquals(2, rows.size());
+        assertEquals(10, rows.get(0).getInt(0));
+        assertEquals("inline_test", rows.get(0).getString(1));
+        assertEquals(20, rows.get(1).getInt(0));
+        assertEquals("inline_read", rows.get(1).getString(1));
+    }
+
+    @Test
+    public void testOverwriteWithInlinedData() {
+        // First write
+        Dataset<Row> df1 = spark.createDataFrame(
+                Arrays.asList(
+                        RowFactory.create(1, "old_data")
+                ),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+        df1.writeTo("ducklake.main.test_inline").append();
+
+        // Overwrite
+        Dataset<Row> df2 = spark.createDataFrame(
+                Arrays.asList(
+                        RowFactory.create(99, "new_data")
+                ),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+        df2.writeTo("ducklake.main.test_inline").overwrite(functions.lit(true));
+
+        Dataset<Row> result = spark.table("ducklake.main.test_inline");
+        List<Row> rows = result.collectAsList();
+        assertEquals(1, rows.size());
+        assertEquals(99, rows.get(0).getInt(0));
+        assertEquals("new_data", rows.get(0).getString(1));
+    }
+
+    @Test
+    public void testMultipleInlinedWrites() {
+        for (int batch = 0; batch < 5; batch++) {
+            Dataset<Row> df = spark.createDataFrame(
+                    Arrays.asList(
+                            RowFactory.create(batch * 10, "batch_" + batch)
+                    ),
+                    new StructType()
+                            .add("id", DataTypes.IntegerType)
+                            .add("name", DataTypes.StringType)
+            );
+            df.writeTo("ducklake.main.test_inline").append();
+        }
+
+        Dataset<Row> result = spark.table("ducklake.main.test_inline");
+        assertEquals(5, result.count());
+    }
+
+    // ---------------------------------------------------------------
+
+    private void deleteDir(File dir) {
+        if (dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    deleteDir(f);
+                }
+            }
+        }
+        dir.delete();
+    }
+}


### PR DESCRIPTION
Store small writes directly in the catalog database instead of creating Parquet files.

## Motivation
Creating a Parquet file for a 1-3 row write is wasteful. Data inlining stores these tiny writes in the catalog database (SQLite/PostgreSQL) directly, matching DuckLake core's `data_inlining_row_limit` feature.

## Changes

### New: DuckLakeInlineWriter
- `shouldInline()`: checks row count against `inline.row_limit` option
- `insertInlinedRows()`: stores rows in dynamically-created catalog tables (`ducklake_inlined_data_{tableId}_{schemaVersion}`)
- `readInlinedRows()`: reads active rows using begin/end snapshot filtering
- `endAllInlinedRows()`: soft-delete for overwrite mode
- Registry: `ducklake_inlined_data_tables` tracks which tables exist
- Type mapping: DuckDB types → SQLite/PostgreSQL storage types (BIGINT, DOUBLE, VARCHAR)

### New: DuckLakeInlinedInputPartition + DuckLakeInlinedPartitionReader
- Reads inlined rows back as Spark InternalRows
- Parses string values back to typed representations

### Modified: DuckLakeMetadataBackend
- `getConnectionForInlining()`: exposes JDBC connection
- `getSchemaVersion()`: retrieves schema version at a snapshot

### Modified: DuckLakeScan
- `planInputPartitions()`: includes inlined data as an additional partition

### Modified: DuckLakePartitionReaderFactory
- Dispatches to inlined reader or Parquet reader based on partition type

### Tests (DuckLakeInliningTest)
- Small writes with no Parquet file overhead
- Read-back verification with correct values
- Overwrite mode with inlined data
- Multiple sequential inlined writes

## Configuration
```
spark.sql.catalog.ducklake.inline.row_limit=100  # max rows to inline (0 = disabled)
```