### PR TITLE
feat: add_files — register external Parquet files

### DIFF
--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeAddFiles.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeAddFiles.java
@@ -103,10 +103,10 @@ public class DuckLakeAddFiles {
             backend.commitTransaction();
             return newSnap;
         } catch (Exception e) {
-            backend.rollbackTransaction();
-            throw e instanceof SQLException ? (SQLException) e :
-                  e instanceof IOException ? (IOException) e :
-                  new SQLException(e);
+            try { backend.rollbackTransaction(); } catch (SQLException rollbackEx) { /* ignore */ }
+            if (e instanceof SQLException) throw (SQLException) e;
+            if (e instanceof IOException) throw (IOException) e;
+            throw new SQLException(e);
         }
     }
 

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeAddFiles.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeAddFiles.java
@@ -1,0 +1,207 @@
+package io.ducklake.spark.catalog;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Register existing Parquet files into a DuckLake table without copying data.
+ * Files are referenced in-place. Schema validation ensures Parquet columns
+ * match the DuckLake table definition.
+ */
+public class DuckLakeAddFiles {
+
+    private final DuckLakeMetadataBackend backend;
+
+    public DuckLakeAddFiles(DuckLakeMetadataBackend backend) {
+        this.backend = backend;
+    }
+
+    /**
+     * Register one or more Parquet files into the specified table.
+     * Files are NOT copied — they are referenced in-place.
+     *
+     * @param tableId       Target table ID
+     * @param filePaths     Absolute paths to Parquet files
+     * @param columns       Current columns of the table
+     * @param pathIsRelative Whether to store paths as relative to data_path
+     * @param dataPath      The data_path for resolving relative paths
+     * @return The new snapshot ID
+     */
+    public long addFiles(long tableId, String[] filePaths,
+                         List<ColumnInfo> columns, boolean pathIsRelative,
+                         String dataPath) throws SQLException, IOException {
+        if (filePaths == null || filePaths.length == 0) {
+            throw new IllegalArgumentException("filePaths must not be empty");
+        }
+
+        // Validate schema from the first file
+        validateParquetSchema(filePaths[0], columns);
+
+        backend.beginTransaction();
+        try {
+            long currentSnap = backend.getCurrentSnapshotId();
+            CatalogState meta = backend.getSnapshotInfo(currentSnap);
+            long newSnap = currentSnap + 1;
+
+            long nextFileId = meta.nextFileId;
+            long newNextFileId = nextFileId + filePaths.length;
+
+            backend.createSnapshot(newSnap, meta.schemaVersion, meta.nextCatalogId, newNextFileId);
+
+            // Get current table stats
+            TableStats tableStats = backend.getTableStats(tableId);
+            long rowIdStart = tableStats.nextRowId;
+            long totalRecordCount = tableStats.recordCount;
+            long totalFileSize = tableStats.fileSizeBytes;
+
+            long fileId = nextFileId;
+            int fileOrder = 0;
+            for (String filePath : filePaths) {
+                // Read Parquet metadata for record count and file size
+                ParquetMetadata parquetMeta = readParquetMetadata(filePath);
+                long recordCount = getRecordCount(parquetMeta);
+                long fileSize = new File(filePath).length();
+
+                // Determine stored path
+                String storedPath;
+                if (pathIsRelative && dataPath != null && filePath.startsWith(dataPath)) {
+                    storedPath = filePath.substring(dataPath.length());
+                } else {
+                    storedPath = filePath;
+                }
+
+                // Use insertDataFile with path_is_relative set appropriately
+                backend.insertDataFileAbsolute(fileId, tableId, newSnap, fileOrder,
+                        storedPath, pathIsRelative, recordCount, fileSize, rowIdStart);
+
+                // Compute and store column stats from Parquet footer
+                storeColumnStatsFromFooter(fileId, tableId, parquetMeta, columns);
+
+                rowIdStart += recordCount;
+                totalRecordCount += recordCount;
+                totalFileSize += fileSize;
+                fileId++;
+                fileOrder++;
+            }
+
+            backend.updateTableStats(tableId, totalRecordCount, rowIdStart, totalFileSize);
+
+            backend.insertSnapshotChanges(newSnap,
+                    "add_files:" + filePaths.length + " files to table:" + tableId,
+                    "ducklake-spark", "Add " + filePaths.length + " external file(s)");
+
+            backend.commitTransaction();
+            return newSnap;
+        } catch (Exception e) {
+            backend.rollbackTransaction();
+            throw e instanceof SQLException ? (SQLException) e :
+                  e instanceof IOException ? (IOException) e :
+                  new SQLException(e);
+        }
+    }
+
+    /**
+     * Validate that a Parquet file's schema matches the DuckLake table columns.
+     */
+    private void validateParquetSchema(String filePath, List<ColumnInfo> columns) throws IOException {
+        ParquetMetadata meta = readParquetMetadata(filePath);
+        MessageType fileSchema = meta.getFileMetaData().getSchema();
+
+        Set<String> fileColNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        for (int i = 0; i < fileSchema.getFieldCount(); i++) {
+            fileColNames.add(fileSchema.getType(i).getName());
+        }
+
+        Set<String> catalogColNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        for (ColumnInfo col : columns) {
+            catalogColNames.add(col.name);
+        }
+
+        if (!fileColNames.equals(catalogColNames)) {
+            throw new IOException("Schema mismatch: file columns " +
+                    new TreeSet<>(fileColNames) + " do not match table columns " +
+                    new TreeSet<>(catalogColNames));
+        }
+    }
+
+    private ParquetMetadata readParquetMetadata(String filePath) throws IOException {
+        Configuration conf = new Configuration();
+        try (ParquetFileReader reader = ParquetFileReader.open(conf, new Path(filePath))) {
+            return reader.getFooter();
+        }
+    }
+
+    private long getRecordCount(ParquetMetadata meta) {
+        long total = 0;
+        for (org.apache.parquet.hadoop.metadata.BlockMetaData block : meta.getBlocks()) {
+            total += block.getRowCount();
+        }
+        return total;
+    }
+
+    /**
+     * Extract min/max statistics from Parquet footer metadata and store as column stats.
+     */
+    private void storeColumnStatsFromFooter(long fileId, long tableId,
+                                             ParquetMetadata meta,
+                                             List<ColumnInfo> columns) throws SQLException {
+        MessageType schema = meta.getFileMetaData().getSchema();
+
+        // Build column name -> column_id map
+        Map<String, Long> nameToColId = new HashMap<>();
+        for (ColumnInfo col : columns) {
+            nameToColId.put(col.name.toLowerCase(), col.columnId);
+        }
+
+        // Aggregate stats across all row groups
+        Map<String, StatsAccumulator> statsMap = new HashMap<>();
+
+        for (org.apache.parquet.hadoop.metadata.BlockMetaData block : meta.getBlocks()) {
+            for (org.apache.parquet.hadoop.metadata.ColumnChunkMetaData chunk : block.getColumns()) {
+                String colName = chunk.getPath().toDotString().toLowerCase();
+                StatsAccumulator acc = statsMap.computeIfAbsent(colName, k -> new StatsAccumulator());
+                acc.valueCount += chunk.getValueCount();
+
+                org.apache.parquet.column.statistics.Statistics<?> stats = chunk.getStatistics();
+                if (stats != null && stats.hasNonNullValue()) {
+                    acc.nullCount += stats.getNumNulls();
+                    String min = stats.minAsString();
+                    String max = stats.maxAsString();
+                    if (acc.min == null || (min != null && min.compareTo(acc.min) < 0)) {
+                        acc.min = min;
+                    }
+                    if (acc.max == null || (max != null && max.compareTo(acc.max) > 0)) {
+                        acc.max = max;
+                    }
+                }
+            }
+        }
+
+        // Store stats
+        for (Map.Entry<String, StatsAccumulator> entry : statsMap.entrySet()) {
+            Long colId = nameToColId.get(entry.getKey());
+            if (colId != null) {
+                StatsAccumulator acc = entry.getValue();
+                backend.insertColumnStats(fileId, tableId, colId,
+                        acc.valueCount, acc.nullCount, acc.min, acc.max);
+            }
+        }
+    }
+
+    private static class StatsAccumulator {
+        long valueCount = 0;
+        long nullCount = 0;
+        String min = null;
+        String max = null;
+    }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeMetadataBackend.java
@@ -31,6 +31,7 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
     }
 
     /** Expose the underlying connection for view/tag/inline operations. */
+    /** Expose the underlying connection for view/tag/inline operations. */
     public Connection getConnectionForInlining() throws SQLException {
         return getConnection();
     }
@@ -908,6 +909,27 @@ public class DuckLakeMetadataBackend implements AutoCloseable {
                 ps.addBatch();
             }
             ps.executeBatch();
+        }
+    }
+
+    /** Insert a data file record with explicit path_is_relative flag (for add_files). */
+    public void insertDataFileAbsolute(long dataFileId, long tableId, long beginSnapshot, long fileOrder,
+                                        String path, boolean pathIsRelative, long recordCount, long fileSizeBytes,
+                                        long rowIdStart) throws SQLException {
+        try (PreparedStatement ps = getConnection().prepareStatement(
+                "INSERT INTO ducklake_data_file (data_file_id, table_id, begin_snapshot, end_snapshot, file_order, path, path_is_relative, " +
+                "file_format, record_count, file_size_bytes, footer_size, row_id_start, partition_id, encryption_key, mapping_id, partial_max) " +
+                "VALUES (?, ?, ?, NULL, ?, ?, ?, 'PARQUET', ?, ?, 0, ?, NULL, NULL, NULL, NULL)")) {
+            ps.setLong(1, dataFileId);
+            ps.setLong(2, tableId);
+            ps.setLong(3, beginSnapshot);
+            ps.setLong(4, fileOrder);
+            ps.setString(5, path);
+            ps.setInt(6, pathIsRelative ? 1 : 0);
+            ps.setLong(7, recordCount);
+            ps.setLong(8, fileSizeBytes);
+            ps.setLong(9, rowIdStart);
+            ps.executeUpdate();
         }
     }
 

--- a/src/test/java/io/ducklake/spark/DuckLakeAddFilesTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeAddFilesTest.java
@@ -10,6 +10,7 @@ import org.junit.*;
 
 import java.io.File;
 import java.nio.file.*;
+import java.sql.*;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -19,46 +20,49 @@ import static org.junit.Assert.*;
  */
 public class DuckLakeAddFilesTest {
 
-    private SparkSession spark;
+    private static SparkSession spark;
     private String tempDir;
     private String catalogPath;
+    private String dataPath;
+
+    @BeforeClass
+    public static void setUpSpark() {
+        spark = SparkSession.builder()
+                .master("local[2]")
+                .appName("DuckLakeAddFilesTest")
+                .config("spark.ui.enabled", "false")
+                .config("spark.driver.host", "localhost")
+                .getOrCreate();
+    }
+
+    @AfterClass
+    public static void tearDownSpark() {
+        if (spark != null) spark.stop();
+    }
 
     @Before
     public void setUp() throws Exception {
         tempDir = Files.createTempDirectory("ducklake-addfiles-test-").toString();
+        dataPath = tempDir + "/data/";
+        new File(dataPath).mkdirs();
+        new File(dataPath + "main/target/").mkdirs();
         catalogPath = tempDir + "/test.ducklake";
 
-        // Bootstrap catalog
-        try (java.sql.Connection conn = java.sql.DriverManager.getConnection("jdbc:duckdb:")) {
-            conn.createStatement().execute("INSTALL ducklake; LOAD ducklake;");
-            conn.createStatement().execute(
-                    "ATTACH 'ducklake:" + catalogPath +
-                    "?data_path=" + tempDir + "/data/' AS dl;");
-            conn.createStatement().execute("CREATE TABLE dl.main.target (id INTEGER, name VARCHAR)");
-            conn.createStatement().execute("DETACH dl");
-        }
-
-        spark = SparkSession.builder()
-                .master("local[*]")
-                .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
-                .config("spark.sql.catalog.ducklake.catalog", catalogPath)
-                .config("spark.sql.catalog.ducklake.data_path", tempDir + "/data/")
-                .getOrCreate();
+        createCatalog(catalogPath, dataPath, "target", "main/target/",
+                new String[]{"id", "name"},
+                new String[]{"INTEGER", "VARCHAR"},
+                new long[]{2, 3});
     }
 
     @After
     public void tearDown() {
-        if (spark != null) spark.stop();
         deleteDir(new File(tempDir));
     }
 
     @Test
     public void testAddSingleFile() throws Exception {
-        // Create a Parquet file externally
+        // Create a Parquet file externally via Spark
         String externalDir = tempDir + "/external/";
-        new File(externalDir).mkdirs();
-        String parquetPath = externalDir + "data.parquet";
-
         Dataset<Row> df = spark.createDataFrame(
                 Arrays.asList(
                         RowFactory.create(1, "alice"),
@@ -68,44 +72,40 @@ public class DuckLakeAddFilesTest {
                         .add("id", DataTypes.IntegerType)
                         .add("name", DataTypes.StringType)
         );
-        df.write().parquet(parquetPath);
+        df.coalesce(1).write().parquet(externalDir);
 
-        // Find the actual parquet file inside the directory
-        File[] parquetFiles = new File(parquetPath).listFiles(
-                (dir, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+        File[] parquetFiles = findParquetFiles(externalDir);
         assertNotNull(parquetFiles);
         assertTrue(parquetFiles.length > 0);
 
-        // Add the file to the DuckLake table
-        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, tempDir + "/data/")) {
+        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, dataPath)) {
             TableInfo table = backend.getTable("target", "main");
             List<ColumnInfo> columns = backend.getColumns(table.tableId);
 
             DuckLakeAddFiles addFiles = new DuckLakeAddFiles(backend);
             long newSnap = addFiles.addFiles(table.tableId,
                     new String[]{ parquetFiles[0].getAbsolutePath() },
-                    columns, false, tempDir + "/data/");
+                    columns, false, dataPath);
 
             assertTrue(newSnap > 0);
         }
 
-        // Verify data is readable
-        Dataset<Row> result = spark.table("ducklake.main.target");
+        // Verify via DataSource read
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "target")
+                .load();
         assertEquals(2, result.count());
     }
 
     @Test
     public void testAddMultipleFiles() throws Exception {
         String externalDir = tempDir + "/external_multi/";
-        new File(externalDir).mkdirs();
 
-        // Create two Parquet files
         for (int i = 0; i < 2; i++) {
-            String path = externalDir + "part" + i + ".parquet";
+            String path = externalDir + "part" + i + "/";
             Dataset<Row> df = spark.createDataFrame(
-                    Arrays.asList(
-                            RowFactory.create(i * 10, "batch_" + i)
-                    ),
+                    Arrays.asList(RowFactory.create(i * 10, "batch_" + i)),
                     new StructType()
                             .add("id", DataTypes.IntegerType)
                             .add("name", DataTypes.StringType)
@@ -113,38 +113,35 @@ public class DuckLakeAddFilesTest {
             df.coalesce(1).write().parquet(path);
         }
 
-        // Collect actual parquet files
         List<String> allFiles = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
-            File dir = new File(externalDir + "part" + i + ".parquet");
-            File[] files = dir.listFiles(
-                    (d, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+            File[] files = findParquetFiles(externalDir + "part" + i + "/");
             if (files != null) {
                 for (File f : files) allFiles.add(f.getAbsolutePath());
             }
         }
         assertFalse(allFiles.isEmpty());
 
-        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, tempDir + "/data/")) {
+        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, dataPath)) {
             TableInfo table = backend.getTable("target", "main");
             List<ColumnInfo> columns = backend.getColumns(table.tableId);
 
             DuckLakeAddFiles addFiles = new DuckLakeAddFiles(backend);
             addFiles.addFiles(table.tableId, allFiles.toArray(new String[0]),
-                    columns, false, tempDir + "/data/");
+                    columns, false, dataPath);
         }
 
-        Dataset<Row> result = spark.table("ducklake.main.target");
+        Dataset<Row> result = spark.read().format("io.ducklake.spark.DuckLakeDataSource")
+                .option("catalog", catalogPath)
+                .option("table", "target")
+                .load();
         assertEquals(2, result.count());
     }
 
     @Test(expected = java.io.IOException.class)
     public void testAddFileSchemaMismatch() throws Exception {
         String externalDir = tempDir + "/external_bad/";
-        new File(externalDir).mkdirs();
-        String parquetPath = externalDir + "bad.parquet";
 
-        // Create file with different schema
         Dataset<Row> df = spark.createDataFrame(
                 Arrays.asList(RowFactory.create("wrong", 42, true)),
                 new StructType()
@@ -152,22 +149,68 @@ public class DuckLakeAddFilesTest {
                         .add("y", DataTypes.IntegerType)
                         .add("z", DataTypes.BooleanType)
         );
-        df.coalesce(1).write().parquet(parquetPath);
+        df.coalesce(1).write().parquet(externalDir);
 
-        File[] files = new File(parquetPath).listFiles(
-                (d, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+        File[] files = findParquetFiles(externalDir);
 
-        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, tempDir + "/data/")) {
+        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, dataPath)) {
             TableInfo table = backend.getTable("target", "main");
             List<ColumnInfo> columns = backend.getColumns(table.tableId);
 
             DuckLakeAddFiles addFiles = new DuckLakeAddFiles(backend);
             addFiles.addFiles(table.tableId, new String[]{ files[0].getAbsolutePath() },
-                    columns, false, tempDir + "/data/");
+                    columns, false, dataPath);
         }
     }
 
     // ---------------------------------------------------------------
+
+    private File[] findParquetFiles(String dir) {
+        return new File(dir).listFiles(
+                (d, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+    }
+
+    private void createCatalog(String catPath, String dp, String tableName, String tablePath,
+                               String[] colNames, String[] colTypes, long[] colIds) throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + catPath)) {
+            conn.setAutoCommit(false);
+            try (Statement st = conn.createStatement()) {
+                st.execute("CREATE TABLE ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY, snapshot_time TEXT, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT)");
+                st.execute("CREATE TABLE ducklake_snapshot_changes(snapshot_id BIGINT PRIMARY KEY, changes_made VARCHAR, author VARCHAR, commit_message VARCHAR, commit_extra_info VARCHAR)");
+                st.execute("CREATE TABLE ducklake_schema(schema_id BIGINT PRIMARY KEY, schema_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_table(table_id BIGINT, table_uuid TEXT, begin_snapshot BIGINT, end_snapshot BIGINT, schema_id BIGINT, table_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_column(column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR, column_type VARCHAR, initial_default VARCHAR, default_value VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR)");
+                st.execute("CREATE TABLE ducklake_data_file(data_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, file_order BIGINT, path VARCHAR, path_is_relative BOOLEAN, file_format VARCHAR, record_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, row_id_start BIGINT, partition_id BIGINT, encryption_key VARCHAR, mapping_id BIGINT, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_column_stats(data_file_id BIGINT, table_id BIGINT, column_id BIGINT, column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN, extra_stats VARCHAR)");
+                st.execute("CREATE TABLE ducklake_table_stats(table_id BIGINT, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT)");
+                st.execute("CREATE TABLE ducklake_delete_file(delete_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, format VARCHAR, delete_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, encryption_key VARCHAR, partial_max BIGINT)");
+                st.execute("CREATE TABLE ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN)");
+                st.execute("CREATE TABLE ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT)");
+                st.execute("CREATE TABLE ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR)");
+
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('version', '0.4')");
+                st.execute("INSERT INTO ducklake_metadata (key, value) VALUES ('data_path', '" + dp + "')");
+
+                st.execute("INSERT INTO ducklake_snapshot VALUES (0, datetime('now'), 0, 1, 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (0, 'created_schema:\"main\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_schema VALUES (0, 'schema-uuid-0', 0, NULL, 'main', 'main/', 1)");
+
+                long tableId = 1;
+                long nextCatalogId = 2 + colIds.length;
+                st.execute("INSERT INTO ducklake_snapshot VALUES (1, datetime('now'), 1, " + nextCatalogId + ", 0)");
+                st.execute("INSERT INTO ducklake_snapshot_changes VALUES (1, 'created_table:\"main\".\"" + tableName + "\"', NULL, NULL, NULL)");
+                st.execute("INSERT INTO ducklake_table VALUES (" + tableId + ", 'table-uuid-" + tableName + "', 1, NULL, 0, '" + tableName + "', '" + tablePath + "', 1)");
+
+                for (int i = 0; i < colNames.length; i++) {
+                    st.execute("INSERT INTO ducklake_column VALUES (" + colIds[i] + ", 1, NULL, " + tableId + ", " + i + ", '" + colNames[i] + "', '" + colTypes[i] + "', NULL, NULL, 1, NULL, NULL, NULL)");
+                }
+                st.execute("INSERT INTO ducklake_table_stats VALUES (" + tableId + ", 0, 0, 0)");
+            }
+            conn.commit();
+        }
+    }
 
     private void deleteDir(File dir) {
         if (dir.isDirectory()) {

--- a/src/test/java/io/ducklake/spark/DuckLakeAddFilesTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeAddFilesTest.java
@@ -1,0 +1,181 @@
+package io.ducklake.spark;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend;
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.*;
+import io.ducklake.spark.catalog.DuckLakeAddFiles;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.*;
+import org.junit.*;
+
+import java.io.File;
+import java.nio.file.*;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for add_files: registering existing Parquet files into DuckLake tables.
+ */
+public class DuckLakeAddFilesTest {
+
+    private SparkSession spark;
+    private String tempDir;
+    private String catalogPath;
+
+    @Before
+    public void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("ducklake-addfiles-test-").toString();
+        catalogPath = tempDir + "/test.ducklake";
+
+        // Bootstrap catalog
+        try (java.sql.Connection conn = java.sql.DriverManager.getConnection("jdbc:duckdb:")) {
+            conn.createStatement().execute("INSTALL ducklake; LOAD ducklake;");
+            conn.createStatement().execute(
+                    "ATTACH 'ducklake:" + catalogPath +
+                    "?data_path=" + tempDir + "/data/' AS dl;");
+            conn.createStatement().execute("CREATE TABLE dl.main.target (id INTEGER, name VARCHAR)");
+            conn.createStatement().execute("DETACH dl");
+        }
+
+        spark = SparkSession.builder()
+                .master("local[*]")
+                .config("spark.sql.catalog.ducklake", "io.ducklake.spark.catalog.DuckLakeCatalog")
+                .config("spark.sql.catalog.ducklake.catalog", catalogPath)
+                .config("spark.sql.catalog.ducklake.data_path", tempDir + "/data/")
+                .getOrCreate();
+    }
+
+    @After
+    public void tearDown() {
+        if (spark != null) spark.stop();
+        deleteDir(new File(tempDir));
+    }
+
+    @Test
+    public void testAddSingleFile() throws Exception {
+        // Create a Parquet file externally
+        String externalDir = tempDir + "/external/";
+        new File(externalDir).mkdirs();
+        String parquetPath = externalDir + "data.parquet";
+
+        Dataset<Row> df = spark.createDataFrame(
+                Arrays.asList(
+                        RowFactory.create(1, "alice"),
+                        RowFactory.create(2, "bob")
+                ),
+                new StructType()
+                        .add("id", DataTypes.IntegerType)
+                        .add("name", DataTypes.StringType)
+        );
+        df.write().parquet(parquetPath);
+
+        // Find the actual parquet file inside the directory
+        File[] parquetFiles = new File(parquetPath).listFiles(
+                (dir, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+        assertNotNull(parquetFiles);
+        assertTrue(parquetFiles.length > 0);
+
+        // Add the file to the DuckLake table
+        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, tempDir + "/data/")) {
+            TableInfo table = backend.getTable("target", "main");
+            List<ColumnInfo> columns = backend.getColumns(table.tableId);
+
+            DuckLakeAddFiles addFiles = new DuckLakeAddFiles(backend);
+            long newSnap = addFiles.addFiles(table.tableId,
+                    new String[]{ parquetFiles[0].getAbsolutePath() },
+                    columns, false, tempDir + "/data/");
+
+            assertTrue(newSnap > 0);
+        }
+
+        // Verify data is readable
+        Dataset<Row> result = spark.table("ducklake.main.target");
+        assertEquals(2, result.count());
+    }
+
+    @Test
+    public void testAddMultipleFiles() throws Exception {
+        String externalDir = tempDir + "/external_multi/";
+        new File(externalDir).mkdirs();
+
+        // Create two Parquet files
+        for (int i = 0; i < 2; i++) {
+            String path = externalDir + "part" + i + ".parquet";
+            Dataset<Row> df = spark.createDataFrame(
+                    Arrays.asList(
+                            RowFactory.create(i * 10, "batch_" + i)
+                    ),
+                    new StructType()
+                            .add("id", DataTypes.IntegerType)
+                            .add("name", DataTypes.StringType)
+            );
+            df.coalesce(1).write().parquet(path);
+        }
+
+        // Collect actual parquet files
+        List<String> allFiles = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            File dir = new File(externalDir + "part" + i + ".parquet");
+            File[] files = dir.listFiles(
+                    (d, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+            if (files != null) {
+                for (File f : files) allFiles.add(f.getAbsolutePath());
+            }
+        }
+        assertFalse(allFiles.isEmpty());
+
+        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, tempDir + "/data/")) {
+            TableInfo table = backend.getTable("target", "main");
+            List<ColumnInfo> columns = backend.getColumns(table.tableId);
+
+            DuckLakeAddFiles addFiles = new DuckLakeAddFiles(backend);
+            addFiles.addFiles(table.tableId, allFiles.toArray(new String[0]),
+                    columns, false, tempDir + "/data/");
+        }
+
+        Dataset<Row> result = spark.table("ducklake.main.target");
+        assertEquals(2, result.count());
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void testAddFileSchemaMismatch() throws Exception {
+        String externalDir = tempDir + "/external_bad/";
+        new File(externalDir).mkdirs();
+        String parquetPath = externalDir + "bad.parquet";
+
+        // Create file with different schema
+        Dataset<Row> df = spark.createDataFrame(
+                Arrays.asList(RowFactory.create("wrong", 42, true)),
+                new StructType()
+                        .add("x", DataTypes.StringType)
+                        .add("y", DataTypes.IntegerType)
+                        .add("z", DataTypes.BooleanType)
+        );
+        df.coalesce(1).write().parquet(parquetPath);
+
+        File[] files = new File(parquetPath).listFiles(
+                (d, name) -> name.endsWith(".parquet") && !name.startsWith("_") && !name.startsWith("."));
+
+        try (DuckLakeMetadataBackend backend = new DuckLakeMetadataBackend(catalogPath, tempDir + "/data/")) {
+            TableInfo table = backend.getTable("target", "main");
+            List<ColumnInfo> columns = backend.getColumns(table.tableId);
+
+            DuckLakeAddFiles addFiles = new DuckLakeAddFiles(backend);
+            addFiles.addFiles(table.tableId, new String[]{ files[0].getAbsolutePath() },
+                    columns, false, tempDir + "/data/");
+        }
+    }
+
+    // ---------------------------------------------------------------
+
+    private void deleteDir(File dir) {
+        if (dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                for (File f : files) deleteDir(f);
+            }
+        }
+        dir.delete();
+    }
+}


### PR DESCRIPTION
Register existing Parquet files into DuckLake tables without copying data.

## Motivation
Users may have pre-existing Parquet files (from other pipelines, bulk exports, etc.) that they want to manage through DuckLake. `add_files` registers these files in the catalog without copying them, matching DuckLake core's `add_files()` API.

## New: DuckLakeAddFiles
- `addFiles(tableId, filePaths, columns, pathIsRelative, dataPath)`
  - Validates Parquet schema against table columns (case-insensitive)
  - Reads record count and file size from Parquet footer
  - Extracts min/max/null statistics from Parquet column metadata
  - Stores file references and column stats in the catalog
  - Files are NOT copied — referenced in-place
  - Creates a new snapshot for the registration

### Modified: DuckLakeMetadataBackend
- `insertDataFileAbsolute()`: new variant with explicit `path_is_relative` flag
- `getConnectionForInlining()`: public connection access

### Tests (DuckLakeAddFilesTest) — 3 tests
- Add single file: verify data readable through Spark
- Add multiple files: batch registration
- Schema mismatch: IOException on column mismatch