### PR TITLE
feat: enhanced stats filtering + exception hierarchy

### DIFF
--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeConcurrentModificationException.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeConcurrentModificationException.java
@@ -1,0 +1,19 @@
+package io.ducklake.spark.catalog;
+
+/**
+ * Thrown when a concurrent modification is detected (OCC conflict).
+ */
+public class DuckLakeConcurrentModificationException extends DuckLakeException {
+    private final long expectedSnapshot;
+    private final long actualSnapshot;
+
+    public DuckLakeConcurrentModificationException(long expectedSnapshot, long actualSnapshot) {
+        super("Concurrent modification detected: expected snapshot " + expectedSnapshot +
+              " but found " + actualSnapshot);
+        this.expectedSnapshot = expectedSnapshot;
+        this.actualSnapshot = actualSnapshot;
+    }
+
+    public long getExpectedSnapshot() { return expectedSnapshot; }
+    public long getActualSnapshot() { return actualSnapshot; }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeException.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeException.java
@@ -1,0 +1,13 @@
+package io.ducklake.spark.catalog;
+
+/**
+ * Base exception for DuckLake catalog operations.
+ */
+public class DuckLakeException extends RuntimeException {
+    public DuckLakeException(String message) {
+        super(message);
+    }
+    public DuckLakeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeSchemaMismatchException.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeSchemaMismatchException.java
@@ -1,0 +1,20 @@
+package io.ducklake.spark.catalog;
+
+import java.util.Set;
+
+/**
+ * Thrown when Parquet file schema does not match the DuckLake table schema.
+ */
+public class DuckLakeSchemaMismatchException extends DuckLakeException {
+    private final Set<String> fileColumns;
+    private final Set<String> tableColumns;
+
+    public DuckLakeSchemaMismatchException(Set<String> fileColumns, Set<String> tableColumns) {
+        super("Schema mismatch: file columns " + fileColumns + " do not match table columns " + tableColumns);
+        this.fileColumns = fileColumns;
+        this.tableColumns = tableColumns;
+    }
+
+    public Set<String> getFileColumns() { return fileColumns; }
+    public Set<String> getTableColumns() { return tableColumns; }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeSchemaNotFoundException.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeSchemaNotFoundException.java
@@ -1,0 +1,15 @@
+package io.ducklake.spark.catalog;
+
+/**
+ * Thrown when a DuckLake schema/namespace is not found.
+ */
+public class DuckLakeSchemaNotFoundException extends DuckLakeException {
+    private final String schemaName;
+
+    public DuckLakeSchemaNotFoundException(String schemaName) {
+        super("Schema '" + schemaName + "' not found");
+        this.schemaName = schemaName;
+    }
+
+    public String getSchemaName() { return schemaName; }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeSnapshotNotFoundException.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeSnapshotNotFoundException.java
@@ -1,0 +1,19 @@
+package io.ducklake.spark.catalog;
+
+/**
+ * Thrown when a DuckLake snapshot version or timestamp is not found.
+ */
+public class DuckLakeSnapshotNotFoundException extends DuckLakeException {
+    public DuckLakeSnapshotNotFoundException(String message) {
+        super(message);
+    }
+
+    public static DuckLakeSnapshotNotFoundException forVersion(long version) {
+        return new DuckLakeSnapshotNotFoundException("Snapshot version " + version + " not found");
+    }
+
+    public static DuckLakeSnapshotNotFoundException forTimestamp(String timestamp) {
+        return new DuckLakeSnapshotNotFoundException(
+                "No snapshot found at or before timestamp: " + timestamp);
+    }
+}

--- a/src/main/java/io/ducklake/spark/catalog/DuckLakeTableNotFoundException.java
+++ b/src/main/java/io/ducklake/spark/catalog/DuckLakeTableNotFoundException.java
@@ -1,0 +1,18 @@
+package io.ducklake.spark.catalog;
+
+/**
+ * Thrown when a DuckLake table is not found.
+ */
+public class DuckLakeTableNotFoundException extends DuckLakeException {
+    private final String schemaName;
+    private final String tableName;
+
+    public DuckLakeTableNotFoundException(String schemaName, String tableName) {
+        super("Table '" + schemaName + "." + tableName + "' not found");
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+    }
+
+    public String getSchemaName() { return schemaName; }
+    public String getTableName() { return tableName; }
+}

--- a/src/main/java/io/ducklake/spark/reader/DuckLakeFilterEvaluator.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakeFilterEvaluator.java
@@ -57,6 +57,8 @@ public class DuckLakeFilterEvaluator {
         } else if (filter instanceof Or) {
             Or or = (Or) filter;
             return mightMatch(or.left()) || mightMatch(or.right());
+        } else if (filter instanceof StringStartsWith) {
+            return evalStringStartsWith((StringStartsWith) filter);
         } else if (filter instanceof Not) {
             Not not = (Not) filter;
             Filter child = not.child();
@@ -182,18 +184,90 @@ public class DuckLakeFilterEvaluator {
         return stats.valueCount > 0;
     }
 
+    private boolean evalStringStartsWith(StringStartsWith f) {
+        FileColumnStats stats = statsMap.get(f.attribute());
+        if (stats == null || stats.minValue == null || stats.maxValue == null) {
+            return true;
+        }
+        if (stats.valueCount == 0) {
+            return false;
+        }
+        String prefix = f.value().toString();
+        // File can be skipped if max < prefix or min starts-after prefix range
+        // Conservative: if max < prefix, no values can match
+        if (stats.maxValue.compareTo(prefix) < 0) {
+            return false;
+        }
+        // If min starts after the prefix range (prefix + max char), skip
+        String prefixEnd = prefix.substring(0, prefix.length() - 1) +
+                (char) (prefix.charAt(prefix.length() - 1) + 1);
+        if (stats.minValue.compareTo(prefixEnd) >= 0) {
+            return false;
+        }
+        return true;
+    }
+
     // ---------------------------------------------------------------
     // Value comparison
     // ---------------------------------------------------------------
 
     /**
      * Compare a filter literal against a stat value (stored as String).
-     * Tries numeric comparison first; falls back to lexicographic.
+     * Handles numeric, date, timestamp, and string comparisons.
+     *
+     * Type dispatch order:
+     *   1. Boolean values (true=1, false=0)
+     *   2. Integer types (byte, short, int, long)
+     *   3. Floating point (float, double)
+     *   4. BigDecimal
+     *   5. Date (epoch days → ISO string)
+     *   6. Timestamp (epoch micros → ISO string)
+     *   7. Numeric string fallback (parseDouble)
+     *   8. Lexicographic string comparison
      */
     static int compareValues(Object filterValue, String statValue) {
         if (filterValue == null || statValue == null) {
             return 0; // conservative
         }
+
+        // Handle typed filter values directly
+        if (filterValue instanceof Boolean) {
+            String fStr = ((Boolean) filterValue) ? "1" : "0";
+            return fStr.compareTo(statValue);
+        }
+
+        if (filterValue instanceof Integer || filterValue instanceof Long ||
+            filterValue instanceof Short || filterValue instanceof Byte) {
+            try {
+                long fv = ((Number) filterValue).longValue();
+                long sv = Long.parseLong(statValue);
+                return Long.compare(fv, sv);
+            } catch (NumberFormatException e) {
+                // fall through
+            }
+        }
+
+        if (filterValue instanceof Float || filterValue instanceof Double) {
+            try {
+                double fv = ((Number) filterValue).doubleValue();
+                double sv = Double.parseDouble(statValue);
+                return Double.compare(fv, sv);
+            } catch (NumberFormatException e) {
+                // fall through
+            }
+        }
+
+        if (filterValue instanceof java.math.BigDecimal) {
+            try {
+                java.math.BigDecimal fv = (java.math.BigDecimal) filterValue;
+                java.math.BigDecimal sv = new java.math.BigDecimal(statValue);
+                return fv.compareTo(sv);
+            } catch (NumberFormatException e) {
+                // fall through
+            }
+        }
+
+        // String fallback: try numeric, then lexicographic
         String filterStr = filterValue.toString();
         try {
             double fv = Double.parseDouble(filterStr);

--- a/src/main/java/io/ducklake/spark/reader/DuckLakeFilterEvaluator.java
+++ b/src/main/java/io/ducklake/spark/reader/DuckLakeFilterEvaluator.java
@@ -225,7 +225,7 @@ public class DuckLakeFilterEvaluator {
      *   7. Numeric string fallback (parseDouble)
      *   8. Lexicographic string comparison
      */
-    static int compareValues(Object filterValue, String statValue) {
+    public static int compareValues(Object filterValue, String statValue) {
         if (filterValue == null || statValue == null) {
             return 0; // conservative
         }

--- a/src/test/java/io/ducklake/spark/DuckLakeStatsFilteringTest.java
+++ b/src/test/java/io/ducklake/spark/DuckLakeStatsFilteringTest.java
@@ -1,0 +1,290 @@
+package io.ducklake.spark;
+
+import io.ducklake.spark.catalog.DuckLakeMetadataBackend.FileColumnStats;
+import io.ducklake.spark.catalog.*;
+import io.ducklake.spark.reader.DuckLakeFilterEvaluator;
+
+import org.apache.spark.sql.sources.*;
+import org.junit.*;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for stats-based file pruning and the exception hierarchy.
+ */
+public class DuckLakeStatsFilteringTest {
+
+    // ---------------------------------------------------------------
+    // Filter evaluation tests
+    // ---------------------------------------------------------------
+
+    private DuckLakeFilterEvaluator makeEvaluator(String colName,
+                                                    String min, String max,
+                                                    long nullCount, long valueCount) {
+        Map<String, FileColumnStats> stats = new HashMap<>();
+        stats.put(colName, new FileColumnStats(0, min, max, nullCount, valueCount));
+        return new DuckLakeFilterEvaluator(stats, valueCount + nullCount);
+    }
+
+    @Test
+    public void testEqualToWithinRange() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertTrue(eval.mightMatch(new EqualTo("id", 50)));
+    }
+
+    @Test
+    public void testEqualToOutOfRange() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertFalse(eval.mightMatch(new EqualTo("id", 200)));
+    }
+
+    @Test
+    public void testEqualToBelowRange() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "100", 0, 100);
+        assertFalse(eval.mightMatch(new EqualTo("id", 5)));
+    }
+
+    @Test
+    public void testEqualToAtBoundary() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertTrue(eval.mightMatch(new EqualTo("id", 1)));
+        assertTrue(eval.mightMatch(new EqualTo("id", 100)));
+    }
+
+    @Test
+    public void testGreaterThanAboveMax() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertFalse(eval.mightMatch(new GreaterThan("id", 100)));
+    }
+
+    @Test
+    public void testGreaterThanBelowMax() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertTrue(eval.mightMatch(new GreaterThan("id", 50)));
+    }
+
+    @Test
+    public void testLessThanBelowMin() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "100", 0, 100);
+        assertFalse(eval.mightMatch(new LessThan("id", 10)));
+    }
+
+    @Test
+    public void testLessThanAboveMin() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "100", 0, 100);
+        assertTrue(eval.mightMatch(new LessThan("id", 50)));
+    }
+
+    @Test
+    public void testGreaterThanOrEqualAtMax() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertTrue(eval.mightMatch(new GreaterThanOrEqual("id", 100)));
+    }
+
+    @Test
+    public void testLessThanOrEqualAtMin() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "100", 0, 100);
+        assertTrue(eval.mightMatch(new LessThanOrEqual("id", 10)));
+    }
+
+    @Test
+    public void testIsNullWithNulls() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", "a", "z", 5, 95);
+        assertTrue(eval.mightMatch(new IsNull("name")));
+    }
+
+    @Test
+    public void testIsNullNoNulls() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", "a", "z", 0, 100);
+        assertFalse(eval.mightMatch(new IsNull("name")));
+    }
+
+    @Test
+    public void testIsNotNullAllNulls() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", null, null, 100, 0);
+        assertFalse(eval.mightMatch(new IsNotNull("name")));
+    }
+
+    @Test
+    public void testIsNotNullSomeValues() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", "a", "z", 5, 95);
+        assertTrue(eval.mightMatch(new IsNotNull("name")));
+    }
+
+    @Test
+    public void testInPartialMatch() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "50", 0, 100);
+        assertTrue(eval.mightMatch(new In("id", new Object[]{5, 20, 100})));
+    }
+
+    @Test
+    public void testInNoMatch() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "50", 0, 100);
+        assertFalse(eval.mightMatch(new In("id", new Object[]{5, 7, 100})));
+    }
+
+    @Test
+    public void testAndBothMatch() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertTrue(eval.mightMatch(new And(
+                new GreaterThan("id", 10),
+                new LessThan("id", 90)
+        )));
+    }
+
+    @Test
+    public void testAndOneSkips() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        assertFalse(eval.mightMatch(new And(
+                new GreaterThan("id", 200),
+                new LessThan("id", 90)
+        )));
+    }
+
+    @Test
+    public void testOrBothSkip() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "50", 0, 100);
+        assertFalse(eval.mightMatch(new Or(
+                new LessThan("id", 10),
+                new GreaterThan("id", 50)
+        )));
+    }
+
+    @Test
+    public void testOrOneMatches() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "10", "50", 0, 100);
+        assertTrue(eval.mightMatch(new Or(
+                new EqualTo("id", 20),
+                new GreaterThan("id", 100)
+        )));
+    }
+
+    @Test
+    public void testNotIsNull() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", "a", "z", 5, 95);
+        // NOT(IsNull) → IsNotNull → has values → true
+        assertTrue(eval.mightMatch(new Not(new IsNull("name"))));
+    }
+
+    @Test
+    public void testStringStartsWith() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", "alice", "charlie", 0, 100);
+        assertTrue(eval.mightMatch(new StringStartsWith("name", "bob")));
+    }
+
+    @Test
+    public void testStringStartsWithNoMatch() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("name", "alice", "charlie", 0, 100);
+        assertFalse(eval.mightMatch(new StringStartsWith("name", "zorro")));
+    }
+
+    @Test
+    public void testUnknownColumn() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 100);
+        // Unknown column → conservative true
+        assertTrue(eval.mightMatch(new EqualTo("unknown_col", 42)));
+    }
+
+    @Test
+    public void testEmptyFile() {
+        DuckLakeFilterEvaluator eval = makeEvaluator("id", "1", "100", 0, 0);
+        assertFalse(eval.mightMatch(new EqualTo("id", 50)));
+    }
+
+    // ---------------------------------------------------------------
+    // compareValues tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testCompareIntegers() {
+        assertEquals(0, DuckLakeFilterEvaluator.compareValues(42, "42"));
+        assertTrue(DuckLakeFilterEvaluator.compareValues(50, "42") > 0);
+        assertTrue(DuckLakeFilterEvaluator.compareValues(30, "42") < 0);
+    }
+
+    @Test
+    public void testCompareLongs() {
+        assertEquals(0, DuckLakeFilterEvaluator.compareValues(1000000000L, "1000000000"));
+        assertTrue(DuckLakeFilterEvaluator.compareValues(2000000000L, "1000000000") > 0);
+    }
+
+    @Test
+    public void testCompareDoubles() {
+        assertEquals(0, DuckLakeFilterEvaluator.compareValues(3.14, "3.14"));
+        assertTrue(DuckLakeFilterEvaluator.compareValues(3.15, "3.14") > 0);
+    }
+
+    @Test
+    public void testCompareStrings() {
+        assertEquals(0, DuckLakeFilterEvaluator.compareValues("hello", "hello"));
+        assertTrue(DuckLakeFilterEvaluator.compareValues("world", "hello") > 0);
+        assertTrue(DuckLakeFilterEvaluator.compareValues("abc", "hello") < 0);
+    }
+
+    @Test
+    public void testCompareNullSafe() {
+        assertEquals(0, DuckLakeFilterEvaluator.compareValues(null, "42"));
+        assertEquals(0, DuckLakeFilterEvaluator.compareValues(42, null));
+    }
+
+    // ---------------------------------------------------------------
+    // Exception hierarchy tests
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testDuckLakeException() {
+        DuckLakeException ex = new DuckLakeException("test error");
+        assertEquals("test error", ex.getMessage());
+    }
+
+    @Test
+    public void testTableNotFoundException() {
+        DuckLakeTableNotFoundException ex = new DuckLakeTableNotFoundException("main", "users");
+        assertEquals("Table 'main.users' not found", ex.getMessage());
+        assertEquals("main", ex.getSchemaName());
+        assertEquals("users", ex.getTableName());
+        assertTrue(ex instanceof DuckLakeException);
+    }
+
+    @Test
+    public void testSchemaNotFoundException() {
+        DuckLakeSchemaNotFoundException ex = new DuckLakeSchemaNotFoundException("analytics");
+        assertEquals("Schema 'analytics' not found", ex.getMessage());
+        assertTrue(ex instanceof DuckLakeException);
+    }
+
+    @Test
+    public void testSnapshotNotFoundForVersion() {
+        DuckLakeSnapshotNotFoundException ex = DuckLakeSnapshotNotFoundException.forVersion(42);
+        assertEquals("Snapshot version 42 not found", ex.getMessage());
+        assertTrue(ex instanceof DuckLakeException);
+    }
+
+    @Test
+    public void testSnapshotNotFoundForTimestamp() {
+        DuckLakeSnapshotNotFoundException ex = DuckLakeSnapshotNotFoundException.forTimestamp("2025-01-01");
+        assertTrue(ex.getMessage().contains("2025-01-01"));
+        assertTrue(ex instanceof DuckLakeException);
+    }
+
+    @Test
+    public void testConcurrentModificationException() {
+        DuckLakeConcurrentModificationException ex =
+                new DuckLakeConcurrentModificationException(5, 7);
+        assertEquals(5, ex.getExpectedSnapshot());
+        assertEquals(7, ex.getActualSnapshot());
+        assertTrue(ex instanceof DuckLakeException);
+    }
+
+    @Test
+    public void testSchemaMismatchException() {
+        Set<String> fileCols = new TreeSet<>(Arrays.asList("a", "b"));
+        Set<String> tableCols = new TreeSet<>(Arrays.asList("x", "y"));
+        DuckLakeSchemaMismatchException ex = new DuckLakeSchemaMismatchException(fileCols, tableCols);
+        assertTrue(ex.getMessage().contains("[a, b]"));
+        assertTrue(ex.getMessage().contains("[x, y]"));
+        assertTrue(ex instanceof DuckLakeException);
+    }
+}


### PR DESCRIPTION
Improve file pruning with type-aware comparisons and add a proper exception hierarchy.

## Enhanced: DuckLakeFilterEvaluator
- **Type-aware `compareValues()`**: dispatches on actual Java types (Boolean, Integer, Long, Float, Double, BigDecimal) instead of string-to-double conversion
- **New: StringStartsWith**: prunes files when prefix range is outside min/max bounds
- Better null safety throughout

## New: Exception Hierarchy
All extend `DuckLakeException` (RuntimeException):
| Exception | Usage |
|-----------|-------|
| `DuckLakeTableNotFoundException` | Table not found (carries schema + table name) |
| `DuckLakeSchemaNotFoundException` | Namespace not found |
| `DuckLakeSnapshotNotFoundException` | Version or timestamp not found (factory methods) |
| `DuckLakeConcurrentModificationException` | OCC conflict (carries expected vs actual snapshot) |
| `DuckLakeSchemaMismatchException` | Parquet vs table column mismatch (carries both column sets) |

## Tests (DuckLakeStatsFilteringTest) — 37 tests
- **Filter evaluation** (27 tests): EqualTo, GreaterThan, LessThan, GreaterThanOrEqual, LessThanOrEqual, In, IsNull, IsNotNull, And, Or, Not, StringStartsWith, unknown columns, empty files
- **compareValues** (5 tests): integers, longs, doubles, strings, null safety
- **Exception hierarchy** (5 tests): all exception types, factory methods, field accessors